### PR TITLE
Shape toolbar sticky note

### DIFF
--- a/packages/common/src/constants.ts
+++ b/packages/common/src/constants.ts
@@ -448,6 +448,7 @@ export const TOOL_TYPE = {
   selection: "selection",
   lasso: "lasso",
   rectangle: "rectangle",
+  stickynote: "stickynote",
   diamond: "diamond",
   ellipse: "ellipse",
   arrow: "arrow",

--- a/packages/element/src/comparisons.ts
+++ b/packages/element/src/comparisons.ts
@@ -2,6 +2,7 @@ import type { ElementOrToolType } from "@excalidraw/excalidraw/types";
 
 export const hasBackground = (type: ElementOrToolType) =>
   type === "rectangle" ||
+  type === "stickynote" ||
   type === "iframe" ||
   type === "embeddable" ||
   type === "ellipse" ||
@@ -11,6 +12,7 @@ export const hasBackground = (type: ElementOrToolType) =>
 
 export const hasStrokeColor = (type: ElementOrToolType) =>
   type === "rectangle" ||
+  type === "stickynote" ||
   type === "ellipse" ||
   type === "diamond" ||
   type === "freedraw" ||
@@ -21,6 +23,7 @@ export const hasStrokeColor = (type: ElementOrToolType) =>
 
 export const hasStrokeWidth = (type: ElementOrToolType) =>
   type === "rectangle" ||
+  type === "stickynote" ||
   type === "iframe" ||
   type === "embeddable" ||
   type === "ellipse" ||
@@ -31,6 +34,7 @@ export const hasStrokeWidth = (type: ElementOrToolType) =>
 
 export const hasStrokeStyle = (type: ElementOrToolType) =>
   type === "rectangle" ||
+  type === "stickynote" ||
   type === "iframe" ||
   type === "embeddable" ||
   type === "ellipse" ||
@@ -40,6 +44,7 @@ export const hasStrokeStyle = (type: ElementOrToolType) =>
 
 export const canChangeRoundness = (type: ElementOrToolType) =>
   type === "rectangle" ||
+  type === "stickynote" ||
   type === "iframe" ||
   type === "embeddable" ||
   type === "line" ||

--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -5387,6 +5387,11 @@ class App extends React.Component<AppProps, AppState> {
           : null,
       } as const;
 
+      const stickyNoteColorOverride =
+        nextActiveTool.type === "stickynote"
+          ? { currentItemBackgroundColor: COLOR_PALETTE.yellow[1] }
+          : {};
+
       if (nextActiveTool.type === "freedraw") {
         this.store.scheduleCapture();
       }
@@ -5395,6 +5400,7 @@ class App extends React.Component<AppProps, AppState> {
         return {
           ...prevState,
           ...commonResets,
+          ...stickyNoteColorOverride,
           activeTool: nextActiveTool,
           ...(keepSelection
             ? {}
@@ -5409,6 +5415,7 @@ class App extends React.Component<AppProps, AppState> {
         return {
           ...prevState,
           ...commonResets,
+          ...stickyNoteColorOverride,
           activeTool: nextActiveTool,
           selectedElementIds: makeNextSelectedElementIds({}, prevState),
           selectedGroupIds: makeNextSelectedElementIds({}, prevState),
@@ -5419,6 +5426,7 @@ class App extends React.Component<AppProps, AppState> {
       return {
         ...prevState,
         ...commonResets,
+        ...stickyNoteColorOverride,
         activeTool: nextActiveTool,
       };
     });
@@ -7526,8 +7534,12 @@ class App extends React.Component<AppProps, AppState> {
       this.state.activeTool.type !== "hand" &&
       this.state.activeTool.type !== "image"
     ) {
+      const elementType =
+        this.state.activeTool.type === "stickynote"
+          ? "rectangle"
+          : this.state.activeTool.type;
       this.createGenericElementOnPointerDown(
-        this.state.activeTool.type,
+        elementType,
         pointerDownState,
       );
     }

--- a/packages/excalidraw/components/icons.tsx
+++ b/packages/excalidraw/components/icons.tsx
@@ -333,6 +333,16 @@ export const RectangleIcon = createIcon(
   tablerIconProps,
 );
 
+// custom: sticky note (square with folded corner)
+export const StickyNoteIcon = createIcon(
+  <g strokeWidth="1.5">
+    <path stroke="none" d="M0 0h24v24H0z" fill="none" />
+    <path d="M4 4h16a1 1 0 0 1 1 1v11a1 1 0 0 1 -1 1h-7l-5 5v-5h-4a1 1 0 0 1 -1 -1v-11a1 1 0 0 1 1 -1z" />
+    <path d="M13 17l5 -5" />
+  </g>,
+  tablerIconProps,
+);
+
 // tabler-icons: square-rotated
 export const DiamondIcon = createIcon(
   <g strokeWidth="1.5">

--- a/packages/excalidraw/components/shapes.tsx
+++ b/packages/excalidraw/components/shapes.tsx
@@ -3,6 +3,7 @@ import { KEYS } from "@excalidraw/common";
 import {
   SelectionIcon,
   RectangleIcon,
+  StickyNoteIcon,
   DiamondIcon,
   EllipseIcon,
   ArrowIcon,
@@ -39,6 +40,14 @@ export const SHAPES = [
     value: "rectangle",
     key: KEYS.R,
     numericKey: KEYS["2"],
+    fillable: true,
+    toolbar: true,
+  },
+  {
+    icon: StickyNoteIcon,
+    value: "stickynote",
+    key: KEYS.S,
+    numericKey: null,
     fillable: true,
     toolbar: true,
   },

--- a/packages/excalidraw/data/restore.ts
+++ b/packages/excalidraw/data/restore.ts
@@ -103,6 +103,7 @@ export const AllowedExcalidrawActiveTools: Record<
   lasso: true,
   text: true,
   rectangle: true,
+  stickynote: true,
   diamond: true,
   ellipse: true,
   line: true,

--- a/packages/excalidraw/locales/en.json
+++ b/packages/excalidraw/locales/en.json
@@ -301,6 +301,7 @@
     "lasso": "Lasso selection",
     "image": "Insert image",
     "rectangle": "Rectangle",
+    "stickynote": "Sticky note",
     "diamond": "Diamond",
     "ellipse": "Ellipse",
     "arrow": "Arrow",

--- a/packages/excalidraw/types.ts
+++ b/packages/excalidraw/types.ts
@@ -144,6 +144,7 @@ export type ToolType =
   | "selection"
   | "lasso"
   | "rectangle"
+  | "stickynote"
   | "diamond"
   | "ellipse"
   | "arrow"


### PR DESCRIPTION
Add a sticky note tool to the shape toolbar to enable quick creation of yellow sticky notes.

This PR implements a new sticky note tool, accessible via the shape toolbar or the 'S' keyboard shortcut. It creates a `rectangle` element with a default yellow background, and includes a new icon, type-safe implementation, and i18n support.

---
[Slack Thread](https://cursor-demoworkspace.slack.com/archives/C0AHFEJA8KD/p1772339531517759?thread_ts=1772339531.517759&cid=C0AHFEJA8KD)

<p><a href="https://cursor.com/agents/bc-7a37dd32-6ae4-54dc-85de-3cda5b591d07"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7a37dd32-6ae4-54dc-85de-3cda5b591d07"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

