### PR TITLE
Shape toolbar sticky note

### DIFF
--- a/packages/common/src/constants.ts
+++ b/packages/common/src/constants.ts
@@ -461,6 +461,7 @@ export const TOOL_TYPE = {
   magicframe: "magicframe",
   embeddable: "embeddable",
   laser: "laser",
+  stickyNote: "stickyNote",
 } as const;
 
 export const EDITOR_LS_KEYS = {

--- a/packages/common/src/keys.ts
+++ b/packages/common/src/keys.ts
@@ -70,6 +70,7 @@ export const KEYS = {
   Y: "y",
   Z: "z",
   K: "k",
+  N: "n",
   W: "w",
 
   0: "0",

--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -285,6 +285,7 @@ import type {
   ExcalidrawElbowArrowElement,
   SceneElementsMap,
   ExcalidrawBindableElement,
+  ExcalidrawRectangleElement,
 } from "@excalidraw/element/types";
 
 import type { Mutable, ValueOf } from "@excalidraw/common/utility-types";
@@ -7521,6 +7522,8 @@ class App extends React.Component<AppProps, AppState> {
         pointerDownState.lastCoords.x,
         pointerDownState.lastCoords.y,
       );
+    } else if (this.state.activeTool.type === TOOL_TYPE.stickyNote) {
+      this.createStickyNoteElementOnPointerDown(pointerDownState);
     } else if (
       this.state.activeTool.type !== "eraser" &&
       this.state.activeTool.type !== "hand" &&
@@ -8985,6 +8988,45 @@ class App extends React.Component<AppProps, AppState> {
         newElement: element,
       });
     }
+  };
+
+  private createStickyNoteElementOnPointerDown = (
+    pointerDownState: PointerDownState,
+  ): void => {
+    const [gridX, gridY] = getGridPoint(
+      pointerDownState.origin.x,
+      pointerDownState.origin.y,
+      this.lastPointerDownEvent?.[KEYS.CTRL_OR_CMD]
+        ? null
+        : this.getEffectiveGridSize(),
+    );
+
+    const topLayerFrame = this.getTopLayerFrameAtSceneCoords({
+      x: gridX,
+      y: gridY,
+    });
+
+    const element = newElement({
+      type: "rectangle" as const,
+      x: gridX,
+      y: gridY,
+      strokeColor: this.state.currentItemStrokeColor,
+      backgroundColor: "#FDEFA3",
+      fillStyle: "solid",
+      strokeWidth: this.state.currentItemStrokeWidth,
+      strokeStyle: this.state.currentItemStrokeStyle,
+      roughness: 0,
+      opacity: this.state.currentItemOpacity,
+      roundness: { type: ROUNDNESS.ADAPTIVE_RADIUS },
+      locked: false,
+      frameId: topLayerFrame ? topLayerFrame.id : null,
+    }) as NonDeleted<ExcalidrawRectangleElement>;
+
+    this.scene.insertElement(element);
+    this.setState({
+      multiElement: null,
+      newElement: element,
+    });
   };
 
   private createFrameElementOnPointerDown = (

--- a/packages/excalidraw/components/icons.tsx
+++ b/packages/excalidraw/components/icons.tsx
@@ -324,6 +324,16 @@ export const LassoIcon = createIcon(
   { fill: "none", width: 22, height: 22, strokeWidth: 1.25 },
 );
 
+export const StickyNoteIcon = createIcon(
+  <g strokeWidth="1.5">
+    <path stroke="none" d="M0 0h24v24H0z" fill="none" />
+    <path d="M5 4h14a1 1 0 0 1 1 1v9.675a1 1 0 0 1-.33.74l-4.94 4.34a1 1 0 0 1-.66.245H5a1 1 0 0 1-1-1V5a1 1 0 0 1 1-1z" />
+    <path d="M15 14v5.09" />
+    <path d="M19.67 13.71H16a1 1 0 0 0-1 1v3.59" />
+  </g>,
+  tablerIconProps,
+);
+
 // tabler-icons: square
 export const RectangleIcon = createIcon(
   <g strokeWidth="1.5">

--- a/packages/excalidraw/components/shapes.tsx
+++ b/packages/excalidraw/components/shapes.tsx
@@ -13,6 +13,7 @@ import {
   EraserIcon,
   laserPointerToolIcon,
   handIcon,
+  StickyNoteIcon,
 } from "./icons";
 
 import type { AppClassProperties } from "../types";
@@ -88,6 +89,14 @@ export const SHAPES = [
     key: KEYS.T,
     numericKey: KEYS["8"],
     fillable: false,
+    toolbar: true,
+  },
+  {
+    icon: StickyNoteIcon,
+    value: "stickyNote",
+    key: KEYS.N,
+    numericKey: null,
+    fillable: true,
     toolbar: true,
   },
   {

--- a/packages/excalidraw/data/restore.ts
+++ b/packages/excalidraw/data/restore.ts
@@ -116,6 +116,7 @@ export const AllowedExcalidrawActiveTools: Record<
   hand: true,
   laser: false,
   magicframe: false,
+  stickyNote: true,
 };
 
 export type RestoredDataState = {

--- a/packages/excalidraw/locales/en.json
+++ b/packages/excalidraw/locales/en.json
@@ -316,6 +316,7 @@
     "magicframe": "Wireframe to code",
     "embeddable": "Web Embed",
     "laser": "Laser pointer",
+    "stickyNote": "Sticky note",
     "hand": "Hand (panning tool)",
     "extraTools": "More tools",
     "mermaidToExcalidraw": "Mermaid to Excalidraw",

--- a/packages/excalidraw/snapping.ts
+++ b/packages/excalidraw/snapping.ts
@@ -1409,6 +1409,7 @@ export const isActiveToolNonLinearSnappable = (
     activeToolType === TOOL_TYPE.frame ||
     activeToolType === TOOL_TYPE.magicframe ||
     activeToolType === TOOL_TYPE.image ||
-    activeToolType === TOOL_TYPE.text
+    activeToolType === TOOL_TYPE.text ||
+    activeToolType === TOOL_TYPE.stickyNote
   );
 };

--- a/packages/excalidraw/types.ts
+++ b/packages/excalidraw/types.ts
@@ -156,7 +156,8 @@ export type ToolType =
   | "frame"
   | "magicframe"
   | "embeddable"
-  | "laser";
+  | "laser"
+  | "stickyNote";
 
 export type ElementOrToolType = ExcalidrawElementType | ToolType | "custom";
 


### PR DESCRIPTION
Add a sticky note tool to the shape toolbar to provide a dedicated quick-access option for creating sticky notes.

The sticky note tool reuses the existing rectangle element type, pre-configuring it with a yellow fill, solid fill style, rounded corners, and zero roughness. This approach allows it to inherit all existing behaviors like selection, resizing, dragging, and text binding without additional implementation.

---
[Slack Thread](https://cursor-demoworkspace.slack.com/archives/C0AHFEJA8KD/p1772391187625639?thread_ts=1772391187.625639&cid=C0AHFEJA8KD)

<p><a href="https://cursor.com/agents/bc-6f600f1c-603e-5657-88ba-0b0ae0a5f713"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6f600f1c-603e-5657-88ba-0b0ae0a5f713"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

