### PR TITLE
Sticky note feature

### DIFF
--- a/packages/common/src/constants.ts
+++ b/packages/common/src/constants.ts
@@ -461,6 +461,7 @@ export const TOOL_TYPE = {
   magicframe: "magicframe",
   embeddable: "embeddable",
   laser: "laser",
+  stickyNote: "stickyNote",
 } as const;
 
 export const EDITOR_LS_KEYS = {

--- a/packages/common/src/keys.ts
+++ b/packages/common/src/keys.ts
@@ -70,6 +70,7 @@ export const KEYS = {
   Y: "y",
   Z: "z",
   K: "k",
+  N: "n",
   W: "w",
 
   0: "0",

--- a/packages/element/src/bounds.ts
+++ b/packages/element/src/bounds.ts
@@ -429,6 +429,7 @@ const _isRectanguloidElement = (
       element.type === "embeddable" ||
       element.type === "frame" ||
       element.type === "magicframe" ||
+      element.type === "stickyNote" ||
       (element.type === "text" && !element.containerId))
   );
 };

--- a/packages/element/src/collision.ts
+++ b/packages/element/src/collision.ts
@@ -440,6 +440,7 @@ export const intersectElementWithLineSegment = (
     case "frame":
     case "selection":
     case "magicframe":
+    case "stickyNote":
       return intersectRectanguloidWithLineSegment(
         element,
         elementsMap,

--- a/packages/element/src/comparisons.ts
+++ b/packages/element/src/comparisons.ts
@@ -7,7 +7,8 @@ export const hasBackground = (type: ElementOrToolType) =>
   type === "ellipse" ||
   type === "diamond" ||
   type === "line" ||
-  type === "freedraw";
+  type === "freedraw" ||
+  type === "stickyNote";
 
 export const hasStrokeColor = (type: ElementOrToolType) =>
   type === "rectangle" ||
@@ -17,7 +18,8 @@ export const hasStrokeColor = (type: ElementOrToolType) =>
   type === "arrow" ||
   type === "line" ||
   type === "text" ||
-  type === "embeddable";
+  type === "embeddable" ||
+  type === "stickyNote";
 
 export const hasStrokeWidth = (type: ElementOrToolType) =>
   type === "rectangle" ||
@@ -27,7 +29,8 @@ export const hasStrokeWidth = (type: ElementOrToolType) =>
   type === "diamond" ||
   type === "freedraw" ||
   type === "arrow" ||
-  type === "line";
+  type === "line" ||
+  type === "stickyNote";
 
 export const hasStrokeStyle = (type: ElementOrToolType) =>
   type === "rectangle" ||
@@ -36,7 +39,8 @@ export const hasStrokeStyle = (type: ElementOrToolType) =>
   type === "ellipse" ||
   type === "diamond" ||
   type === "arrow" ||
-  type === "line";
+  type === "line" ||
+  type === "stickyNote";
 
 export const canChangeRoundness = (type: ElementOrToolType) =>
   type === "rectangle" ||
@@ -44,7 +48,8 @@ export const canChangeRoundness = (type: ElementOrToolType) =>
   type === "embeddable" ||
   type === "line" ||
   type === "diamond" ||
-  type === "image";
+  type === "image" ||
+  type === "stickyNote";
 
 export const toolIsArrow = (type: ElementOrToolType) => type === "arrow";
 

--- a/packages/element/src/distance.ts
+++ b/packages/element/src/distance.ts
@@ -40,6 +40,7 @@ export const distanceToElement = (
     case "embeddable":
     case "frame":
     case "magicframe":
+    case "stickyNote":
       return distanceToRectanguloidElement(element, elementsMap, p);
     case "diamond":
       return distanceToDiamondElement(element, elementsMap, p);

--- a/packages/element/src/renderElement.ts
+++ b/packages/element/src/renderElement.ts
@@ -394,12 +394,25 @@ const drawElementOnCanvas = (
     case "rectangle":
     case "iframe":
     case "embeddable":
+    case "stickyNote":
     case "diamond":
     case "ellipse": {
       context.lineJoin = "round";
       context.lineCap = "round";
 
+      if (element.type === "stickyNote") {
+        context.save();
+        context.shadowColor = "rgba(0, 0, 0, 0.15)";
+        context.shadowBlur = 8;
+        context.shadowOffsetX = 2;
+        context.shadowOffsetY = 3;
+      }
+
       rc.draw(ShapeCache.generateElementShape(element, renderConfig));
+
+      if (element.type === "stickyNote") {
+        context.restore();
+      }
       break;
     }
     case "arrow":
@@ -886,7 +899,8 @@ export const renderElement = (
     case "image":
     case "text":
     case "iframe":
-    case "embeddable": {
+    case "embeddable":
+    case "stickyNote": {
       if (renderConfig.isExporting) {
         const [x1, y1, x2, y2] = getElementAbsoluteCoords(element, elementsMap);
         const cx = (x1 + x2) / 2 + appState.scrollX;

--- a/packages/element/src/shape.ts
+++ b/packages/element/src/shape.ts
@@ -229,6 +229,7 @@ export const generateRoughOptions = (
     case "rectangle":
     case "iframe":
     case "embeddable":
+    case "stickyNote":
     case "diamond":
     case "ellipse": {
       options.fillStyle = element.fillStyle;
@@ -646,10 +647,9 @@ const _generateElementShape = (
   switch (element.type) {
     case "rectangle":
     case "iframe":
-    case "embeddable": {
+    case "embeddable":
+    case "stickyNote": {
       let shape: ElementShapes[typeof element.type];
-      // this is for rendering the stroke/bg of the embeddable, especially
-      // when the src url is not set
 
       if (element.roundness) {
         const w = element.width;
@@ -959,6 +959,7 @@ export const getElementShape = <Point extends GlobalPoint | LocalPoint>(
     case "iframe":
     case "text":
     case "selection":
+    case "stickyNote":
       return getPolygonShape(element);
     case "arrow":
     case "line": {

--- a/packages/element/src/textElement.ts
+++ b/packages/element/src/textElement.ts
@@ -437,6 +437,7 @@ const VALID_CONTAINER_TYPES = new Set([
   "ellipse",
   "diamond",
   "arrow",
+  "stickyNote",
 ]);
 
 export const isValidTextContainer = (element: {

--- a/packages/element/src/transform.ts
+++ b/packages/element/src/transform.ts
@@ -307,7 +307,8 @@ const bindLinearElementToElement = (
         switch (startType) {
           case "rectangle":
           case "ellipse":
-          case "diamond": {
+          case "diamond":
+          case "stickyNote": {
             startBoundElement = newElement({
               x: startX,
               y: startY,
@@ -383,7 +384,8 @@ const bindLinearElementToElement = (
         switch (endType) {
           case "rectangle":
           case "ellipse":
-          case "diamond": {
+          case "diamond":
+          case "stickyNote": {
             endBoundElement = newElement({
               x: endX,
               y: endY,
@@ -529,7 +531,8 @@ export const convertToExcalidrawElements = (
     switch (element.type) {
       case "rectangle":
       case "ellipse":
-      case "diamond": {
+      case "diamond":
+      case "stickyNote": {
         const width =
           element?.label?.text && element.width === undefined
             ? 0
@@ -662,6 +665,7 @@ export const convertToExcalidrawElements = (
       case "rectangle":
       case "ellipse":
       case "diamond":
+      case "stickyNote":
       case "arrow": {
         if (element.label?.text) {
           let [container, text] = bindTextToContainer(

--- a/packages/element/src/typeChecks.ts
+++ b/packages/element/src/typeChecks.ts
@@ -29,6 +29,7 @@ import type {
   ExcalidrawLineElement,
   ExcalidrawFlowchartNodeElement,
   ExcalidrawLinearElementSubType,
+  ExcalidrawStickyNoteElement,
 } from "./types";
 
 export const isInitializedImageElement = (
@@ -47,6 +48,12 @@ export const isEmbeddableElement = (
   element: ExcalidrawElement | null | undefined,
 ): element is ExcalidrawEmbeddableElement => {
   return !!element && element.type === "embeddable";
+};
+
+export const isStickyNoteElement = (
+  element: ExcalidrawElement | null | undefined,
+): element is ExcalidrawStickyNoteElement => {
+  return !!element && element.type === "stickyNote";
 };
 
 export const isIframeElement = (
@@ -189,6 +196,7 @@ export const isBindableElement = (
       element.type === "embeddable" ||
       element.type === "frame" ||
       element.type === "magicframe" ||
+      element.type === "stickyNote" ||
       (element.type === "text" && !element.containerId))
   );
 };
@@ -205,6 +213,7 @@ export const isRectanguloidElement = (
       element.type === "embeddable" ||
       element.type === "frame" ||
       element.type === "magicframe" ||
+      element.type === "stickyNote" ||
       (element.type === "text" && !element.containerId))
   );
 };
@@ -223,7 +232,8 @@ export const isRectangularElement = (
       element.type === "embeddable" ||
       element.type === "frame" ||
       element.type === "magicframe" ||
-      element.type === "freedraw")
+      element.type === "freedraw" ||
+      element.type === "stickyNote")
   );
 };
 
@@ -237,6 +247,7 @@ export const isTextBindableContainer = (
     (element.type === "rectangle" ||
       element.type === "diamond" ||
       element.type === "ellipse" ||
+      element.type === "stickyNote" ||
       isArrowElement(element))
   );
 };
@@ -261,7 +272,8 @@ export const isExcalidrawElement = (
     case "frame":
     case "magicframe":
     case "image":
-    case "selection": {
+    case "selection":
+    case "stickyNote": {
       return true;
     }
     default: {
@@ -277,7 +289,8 @@ export const isFlowchartNodeElement = (
   return (
     element.type === "rectangle" ||
     element.type === "ellipse" ||
-    element.type === "diamond"
+    element.type === "diamond" ||
+    element.type === "stickyNote"
   );
 };
 
@@ -309,7 +322,8 @@ export const isUsingAdaptiveRadius = (type: string) =>
   type === "rectangle" ||
   type === "embeddable" ||
   type === "iframe" ||
-  type === "image";
+  type === "image" ||
+  type === "stickyNote";
 
 export const isUsingProportionalRadius = (type: string) =>
   type === "line" || type === "arrow" || type === "diamond";

--- a/packages/element/src/types.ts
+++ b/packages/element/src/types.ts
@@ -97,6 +97,10 @@ export type ExcalidrawEllipseElement = _ExcalidrawElementBase & {
   type: "ellipse";
 };
 
+export type ExcalidrawStickyNoteElement = _ExcalidrawElementBase & {
+  type: "stickyNote";
+};
+
 export type ExcalidrawEmbeddableElement = _ExcalidrawElementBase &
   Readonly<{
     type: "embeddable";
@@ -181,12 +185,14 @@ export type ExcalidrawGenericElement =
   | ExcalidrawSelectionElement
   | ExcalidrawRectangleElement
   | ExcalidrawDiamondElement
-  | ExcalidrawEllipseElement;
+  | ExcalidrawEllipseElement
+  | ExcalidrawStickyNoteElement;
 
 export type ExcalidrawFlowchartNodeElement =
   | ExcalidrawRectangleElement
   | ExcalidrawDiamondElement
-  | ExcalidrawEllipseElement;
+  | ExcalidrawEllipseElement
+  | ExcalidrawStickyNoteElement;
 
 export type ExcalidrawRectanguloidElement =
   | ExcalidrawRectangleElement
@@ -196,7 +202,8 @@ export type ExcalidrawRectanguloidElement =
   | ExcalidrawIframeLikeElement
   | ExcalidrawFrameLikeElement
   | ExcalidrawEmbeddableElement
-  | ExcalidrawSelectionElement;
+  | ExcalidrawSelectionElement
+  | ExcalidrawStickyNoteElement;
 
 /**
  * ExcalidrawElement should be JSON serializable and (eventually) contain
@@ -265,13 +272,15 @@ export type ExcalidrawBindableElement =
   | ExcalidrawIframeElement
   | ExcalidrawEmbeddableElement
   | ExcalidrawFrameElement
-  | ExcalidrawMagicFrameElement;
+  | ExcalidrawMagicFrameElement
+  | ExcalidrawStickyNoteElement;
 
 export type ExcalidrawTextContainer =
   | ExcalidrawRectangleElement
   | ExcalidrawDiamondElement
   | ExcalidrawEllipseElement
-  | ExcalidrawArrowElement;
+  | ExcalidrawArrowElement
+  | ExcalidrawStickyNoteElement;
 
 export type ExcalidrawTextElementWithContainer = {
   containerId: ExcalidrawTextContainer["id"];

--- a/packages/element/src/utils.ts
+++ b/packages/element/src/utils.ts
@@ -511,7 +511,8 @@ const getDiagonalsForBindableElement = (
 ) => {
   // for rectangles, shrink the diagonals a bit because there's something
   // going on with the focus points around the corners. Ask Mark for details.
-  const OFFSET_PX = element.type === "rectangle" ? 15 : 0;
+  const OFFSET_PX =
+    element.type === "rectangle" || element.type === "stickyNote" ? 15 : 0;
   const shrinkSegment = (seg: LineSegment<GlobalPoint>) => {
     const v = vectorNormalize(vectorFromPoint(seg[1], seg[0]));
     const offset = vectorScale(v, OFFSET_PX);

--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -8918,7 +8918,8 @@ class App extends React.Component<AppProps, AppState> {
       | "diamond"
       | "ellipse"
       | "iframe"
-      | "embeddable",
+      | "embeddable"
+      | "stickyNote",
   ) {
     return this.state.currentItemRoundness === "round"
       ? {
@@ -8946,20 +8947,28 @@ class App extends React.Component<AppProps, AppState> {
       y: gridY,
     });
 
+    const isStickyNote = elementType === "stickyNote";
+
     const baseElementAttributes = {
       x: gridX,
       y: gridY,
-      strokeColor: this.state.currentItemStrokeColor,
-      backgroundColor: this.state.currentItemBackgroundColor,
-      fillStyle: this.state.currentItemFillStyle,
-      strokeWidth: this.state.currentItemStrokeWidth,
+      strokeColor: isStickyNote ? "#D4C17D" : this.state.currentItemStrokeColor,
+      backgroundColor: isStickyNote
+        ? "#FDEFA3"
+        : this.state.currentItemBackgroundColor,
+      fillStyle: isStickyNote
+        ? ("solid" as const)
+        : this.state.currentItemFillStyle,
+      strokeWidth: isStickyNote ? 1 : this.state.currentItemStrokeWidth,
       strokeStyle: this.state.currentItemStrokeStyle,
-      roughness: this.state.currentItemRoughness,
+      roughness: isStickyNote ? 0 : this.state.currentItemRoughness,
       opacity: this.state.currentItemOpacity,
-      roundness: this.getCurrentItemRoundness(elementType),
+      roundness: isStickyNote
+        ? { type: ROUNDNESS.ADAPTIVE_RADIUS }
+        : this.getCurrentItemRoundness(elementType),
       locked: false,
       frameId: topLayerFrame ? topLayerFrame.id : null,
-    } as const;
+    };
 
     let element;
     if (elementType === "embeddable") {

--- a/packages/excalidraw/components/HelpDialog.tsx
+++ b/packages/excalidraw/components/HelpDialog.tsx
@@ -160,6 +160,7 @@ export const HelpDialog = ({ onClose }: { onClose?: () => void }) => {
               label={t("toolBar.ellipse")}
               shortcuts={[KEYS.O, KEYS["4"]]}
             />
+            <Shortcut label={t("toolBar.stickyNote")} shortcuts={[KEYS.N]} />
             <Shortcut
               label={t("toolBar.arrow")}
               shortcuts={[KEYS.A, KEYS["5"]]}

--- a/packages/excalidraw/components/MobileToolBar.tsx
+++ b/packages/excalidraw/components/MobileToolBar.tsx
@@ -34,6 +34,7 @@ import {
   LassoIcon,
   mermaidLogoIcon,
   MagicIcon,
+  StickyNoteIcon,
 } from "./icons";
 
 import "./ToolIcon.scss";
@@ -56,6 +57,11 @@ const SHAPE_TOOLS = [
     type: "ellipse",
     icon: EllipseIcon,
     title: capitalizeString(t("toolBar.ellipse")),
+  },
+  {
+    type: "stickyNote",
+    icon: StickyNoteIcon,
+    title: capitalizeString(t("toolBar.stickyNote")),
   },
 ] as const;
 
@@ -95,7 +101,7 @@ export const MobileToolBar = ({
   const activeTool = app.state.activeTool;
   const [isOtherShapesMenuOpen, setIsOtherShapesMenuOpen] = useState(false);
   const [lastActiveGenericShape, setLastActiveGenericShape] = useState<
-    "rectangle" | "diamond" | "ellipse"
+    "rectangle" | "diamond" | "ellipse" | "stickyNote"
   >("rectangle");
   const [lastActiveLinearElement, setLastActiveLinearElement] = useState<
     "arrow" | "line"
@@ -106,7 +112,8 @@ export const MobileToolBar = ({
     if (
       activeTool.type === "rectangle" ||
       activeTool.type === "diamond" ||
-      activeTool.type === "ellipse"
+      activeTool.type === "ellipse" ||
+      activeTool.type === "stickyNote"
     ) {
       setLastActiveGenericShape(activeTool.type);
     }

--- a/packages/excalidraw/components/icons.tsx
+++ b/packages/excalidraw/components/icons.tsx
@@ -333,6 +333,15 @@ export const RectangleIcon = createIcon(
   tablerIconProps,
 );
 
+export const StickyNoteIcon = createIcon(
+  <g strokeWidth="1.5">
+    <path stroke="none" d="M0 0h24v24H0z" fill="none" />
+    <path d="M5 4h14a1 1 0 0 1 1 1v9.5l-5.5 5.5H5a1 1 0 0 1-1-4V5a1 1 0 0 1 1-1z" />
+    <path d="M14.5 14.5V20L20 14.5H14.5z" />
+  </g>,
+  tablerIconProps,
+);
+
 // tabler-icons: square-rotated
 export const DiamondIcon = createIcon(
   <g strokeWidth="1.5">

--- a/packages/excalidraw/components/shapes.tsx
+++ b/packages/excalidraw/components/shapes.tsx
@@ -13,6 +13,7 @@ import {
   EraserIcon,
   laserPointerToolIcon,
   handIcon,
+  StickyNoteIcon,
 } from "./icons";
 
 import type { AppClassProperties } from "../types";
@@ -55,6 +56,14 @@ export const SHAPES = [
     value: "ellipse",
     key: KEYS.O,
     numericKey: KEYS["4"],
+    fillable: true,
+    toolbar: true,
+  },
+  {
+    icon: StickyNoteIcon,
+    value: "stickyNote",
+    key: KEYS.N,
+    numericKey: null,
     fillable: true,
     toolbar: true,
   },

--- a/packages/excalidraw/data/restore.ts
+++ b/packages/excalidraw/data/restore.ts
@@ -116,6 +116,7 @@ export const AllowedExcalidrawActiveTools: Record<
   hand: true,
   laser: false,
   magicframe: false,
+  stickyNote: true,
 };
 
 export type RestoredDataState = {
@@ -519,6 +520,7 @@ export const restoreElement = (
     case "diamond":
     case "iframe":
     case "embeddable":
+    case "stickyNote":
       return restoreElementWithProperties(element, {});
     case "magicframe":
     case "frame":

--- a/packages/excalidraw/locales/en.json
+++ b/packages/excalidraw/locales/en.json
@@ -316,6 +316,7 @@
     "magicframe": "Wireframe to code",
     "embeddable": "Web Embed",
     "laser": "Laser pointer",
+    "stickyNote": "Sticky Note",
     "hand": "Hand (panning tool)",
     "extraTools": "More tools",
     "mermaidToExcalidraw": "Mermaid to Excalidraw",
@@ -335,6 +336,7 @@
     "magicframe": "Wireframe to code",
     "embeddable": "Web Embed",
     "selection": "Selection",
+    "stickyNote": "Sticky Note",
     "iframe": "IFrame"
   },
   "headings": {

--- a/packages/excalidraw/renderer/staticSvgScene.ts
+++ b/packages/excalidraw/renderer/staticSvgScene.ts
@@ -147,7 +147,8 @@ const renderElementToSvg = (
     }
     case "rectangle":
     case "diamond":
-    case "ellipse": {
+    case "ellipse":
+    case "stickyNote": {
       const shape = ShapeCache.generateElementShape(element, renderConfig);
       const node = roughSVGDrawWithPrecision(
         rsvg,
@@ -159,12 +160,30 @@ const renderElementToSvg = (
         node.setAttribute("fill-opacity", `${opacity}`);
       }
       node.setAttribute("stroke-linecap", "round");
-      node.setAttribute(
-        "transform",
-        `translate(${offsetX || 0} ${
-          offsetY || 0
-        }) rotate(${degree} ${cx} ${cy})`,
-      );
+
+      const transformAttr = `translate(${offsetX || 0} ${
+        offsetY || 0
+      }) rotate(${degree} ${cx} ${cy})`;
+
+      if (element.type === "stickyNote") {
+        const filterId = `stickyNote-shadow-${element.id}`;
+        const filter = svgRoot.ownerDocument!.createElementNS(SVG_NS, "filter");
+        filter.setAttribute("id", filterId);
+        const feDropShadow = svgRoot.ownerDocument!.createElementNS(
+          SVG_NS,
+          "feDropShadow",
+        );
+        feDropShadow.setAttribute("dx", "2");
+        feDropShadow.setAttribute("dy", "3");
+        feDropShadow.setAttribute("stdDeviation", "4");
+        feDropShadow.setAttribute("flood-color", "rgba(0,0,0,0.15)");
+        filter.appendChild(feDropShadow);
+        svgRoot.querySelector("defs")?.appendChild(filter) ||
+          svgRoot.insertBefore(filter, svgRoot.firstChild);
+        node.setAttribute("filter", `url(#${filterId})`);
+      }
+
+      node.setAttribute("transform", transformAttr);
 
       const g = maybeWrapNodesInFrameClipPath(
         element,

--- a/packages/excalidraw/scene/types.ts
+++ b/packages/excalidraw/scene/types.ts
@@ -165,6 +165,7 @@ export type ElementShapes = {
   diamond: Drawable;
   iframe: Drawable;
   embeddable: Drawable;
+  stickyNote: Drawable;
   freedraw: (Drawable | SVGPathString)[];
   arrow: Drawable[];
   line: Drawable[];

--- a/packages/excalidraw/snapping.ts
+++ b/packages/excalidraw/snapping.ts
@@ -1409,6 +1409,7 @@ export const isActiveToolNonLinearSnappable = (
     activeToolType === TOOL_TYPE.frame ||
     activeToolType === TOOL_TYPE.magicframe ||
     activeToolType === TOOL_TYPE.image ||
-    activeToolType === TOOL_TYPE.text
+    activeToolType === TOOL_TYPE.text ||
+    activeToolType === TOOL_TYPE.stickyNote
   );
 };

--- a/packages/excalidraw/tests/helpers/api.ts
+++ b/packages/excalidraw/tests/helpers/api.ts
@@ -281,8 +281,9 @@ export class API {
       case "rectangle":
       case "diamond":
       case "ellipse":
+      case "stickyNote":
         element = newElement({
-          type: type as "rectangle" | "diamond" | "ellipse",
+          type: type as "rectangle" | "diamond" | "ellipse" | "stickyNote",
           ...base,
         });
         break;

--- a/packages/excalidraw/tests/helpers/ui.ts
+++ b/packages/excalidraw/tests/helpers/ui.ts
@@ -33,6 +33,7 @@ import type {
   ExcalidrawRectangleElement,
   ExcalidrawEllipseElement,
   ExcalidrawDiamondElement,
+  ExcalidrawStickyNoteElement,
   ExcalidrawTextContainer,
   ExcalidrawTextElementWithContainer,
   ExcalidrawImageElement,
@@ -443,6 +444,8 @@ type Element<T extends DrawingToolName> = T extends "line" | "freedraw"
   ? ExcalidrawEllipseElement
   : T extends "diamond"
   ? ExcalidrawDiamondElement
+  : T extends "stickyNote"
+  ? ExcalidrawStickyNoteElement
   : ExcalidrawElement;
 
 export class UI {

--- a/packages/excalidraw/types.ts
+++ b/packages/excalidraw/types.ts
@@ -156,7 +156,8 @@ export type ToolType =
   | "frame"
   | "magicframe"
   | "embeddable"
-  | "laser";
+  | "laser"
+  | "stickyNote";
 
 export type ElementOrToolType = ExcalidrawElementType | ToolType | "custom";
 

--- a/packages/utils/src/shape.ts
+++ b/packages/utils/src/shape.ts
@@ -50,6 +50,7 @@ import type {
   ExcalidrawLinearElement,
   ExcalidrawRectangleElement,
   ExcalidrawSelectionElement,
+  ExcalidrawStickyNoteElement,
   ExcalidrawTextElement,
 } from "@excalidraw/element/types";
 import type { Curve, LineSegment, Polygon, Radians } from "@excalidraw/math";
@@ -110,7 +111,8 @@ type RectangularElement =
   | ExcalidrawImageElement
   | ExcalidrawIframeElement
   | ExcalidrawTextElement
-  | ExcalidrawSelectionElement;
+  | ExcalidrawSelectionElement
+  | ExcalidrawStickyNoteElement;
 
 // polygon
 export const getPolygonShape = <Point extends GlobalPoint | LocalPoint>(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Implement the sticky note feature to provide a new element type for quick note-taking, addressing issue #4.

This PR introduces a new `stickyNote` element type with a dedicated toolbar icon (shortcut `N`), supporting text editing, resizing, and full property controls. It includes custom rendering (yellow fill, rounded corners, drop shadow, architect-style roughness), SVG export, and mobile toolbar integration. All changes are type-checked, linted, tested, and manually verified.

---
[Slack Thread](https://cursor-demoworkspace.slack.com/archives/C0AJ7MQFH44/p1772498495619899?thread_ts=1772498495.619899&cid=C0AJ7MQFH44)

<p><a href="https://cursor.com/agents/bc-3c132936-fa3e-55c3-8aa4-bfbbdb075415"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3c132936-fa3e-55c3-8aa4-bfbbdb075415"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->