### PR TITLE
Sticky note feature

### DIFF
--- a/packages/common/src/constants.ts
+++ b/packages/common/src/constants.ts
@@ -461,6 +461,7 @@ export const TOOL_TYPE = {
   magicframe: "magicframe",
   embeddable: "embeddable",
   laser: "laser",
+  stickyNote: "stickyNote",
 } as const;
 
 export const EDITOR_LS_KEYS = {

--- a/packages/element/src/collision.ts
+++ b/packages/element/src/collision.ts
@@ -440,6 +440,7 @@ export const intersectElementWithLineSegment = (
     case "frame":
     case "selection":
     case "magicframe":
+    case "stickyNote":
       return intersectRectanguloidWithLineSegment(
         element,
         elementsMap,

--- a/packages/element/src/comparisons.ts
+++ b/packages/element/src/comparisons.ts
@@ -7,7 +7,8 @@ export const hasBackground = (type: ElementOrToolType) =>
   type === "ellipse" ||
   type === "diamond" ||
   type === "line" ||
-  type === "freedraw";
+  type === "freedraw" ||
+  type === "stickyNote";
 
 export const hasStrokeColor = (type: ElementOrToolType) =>
   type === "rectangle" ||
@@ -17,7 +18,8 @@ export const hasStrokeColor = (type: ElementOrToolType) =>
   type === "arrow" ||
   type === "line" ||
   type === "text" ||
-  type === "embeddable";
+  type === "embeddable" ||
+  type === "stickyNote";
 
 export const hasStrokeWidth = (type: ElementOrToolType) =>
   type === "rectangle" ||
@@ -27,7 +29,8 @@ export const hasStrokeWidth = (type: ElementOrToolType) =>
   type === "diamond" ||
   type === "freedraw" ||
   type === "arrow" ||
-  type === "line";
+  type === "line" ||
+  type === "stickyNote";
 
 export const hasStrokeStyle = (type: ElementOrToolType) =>
   type === "rectangle" ||
@@ -36,7 +39,8 @@ export const hasStrokeStyle = (type: ElementOrToolType) =>
   type === "ellipse" ||
   type === "diamond" ||
   type === "arrow" ||
-  type === "line";
+  type === "line" ||
+  type === "stickyNote";
 
 export const canChangeRoundness = (type: ElementOrToolType) =>
   type === "rectangle" ||
@@ -44,7 +48,8 @@ export const canChangeRoundness = (type: ElementOrToolType) =>
   type === "embeddable" ||
   type === "line" ||
   type === "diamond" ||
-  type === "image";
+  type === "image" ||
+  type === "stickyNote";
 
 export const toolIsArrow = (type: ElementOrToolType) => type === "arrow";
 

--- a/packages/element/src/distance.ts
+++ b/packages/element/src/distance.ts
@@ -40,6 +40,7 @@ export const distanceToElement = (
     case "embeddable":
     case "frame":
     case "magicframe":
+    case "stickyNote":
       return distanceToRectanguloidElement(element, elementsMap, p);
     case "diamond":
       return distanceToDiamondElement(element, elementsMap, p);

--- a/packages/element/src/newElement.ts
+++ b/packages/element/src/newElement.ts
@@ -48,6 +48,7 @@ import type {
   ExcalidrawArrowElement,
   ExcalidrawElbowArrowElement,
   ExcalidrawLineElement,
+  ExcalidrawStickyNoteElement,
 } from "./types";
 
 export type ElementConstructorOpts = MarkOptional<
@@ -543,4 +544,49 @@ export const newImageElement = (
     scale: opts.scale ?? [1, 1],
     crop: opts.crop ?? null,
   };
+};
+
+export const STICKY_NOTE_DEFAULT_WIDTH = 200;
+export const STICKY_NOTE_DEFAULT_HEIGHT = 200;
+export const STICKY_NOTE_DEFAULT_COLOR = "#FDEFA3";
+export const STICKY_NOTE_CORNER_RADIUS = 10;
+export const STICKY_NOTE_PADDING = 16;
+
+export const newStickyNoteElement = (
+  opts: {
+    text?: string;
+    originalText?: string;
+    fontSize?: number;
+    fontFamily?: FontFamilyValues;
+    textAlign?: TextAlign;
+    verticalAlign?: VerticalAlign;
+    lineHeight?: ExcalidrawStickyNoteElement["lineHeight"];
+  } & ElementConstructorOpts,
+): NonDeleted<ExcalidrawStickyNoteElement> => {
+  const fontFamily = opts.fontFamily || DEFAULT_FONT_FAMILY;
+  const fontSize = opts.fontSize || DEFAULT_FONT_SIZE;
+  const lineHeight = opts.lineHeight || getLineHeight(fontFamily);
+  const text = normalizeText(opts.text ?? "");
+
+  return newElementWith(
+    {
+      ..._newElementBase<ExcalidrawStickyNoteElement>("stickyNote", {
+        ...opts,
+        width: opts.width || STICKY_NOTE_DEFAULT_WIDTH,
+        height: opts.height || STICKY_NOTE_DEFAULT_HEIGHT,
+        backgroundColor: opts.backgroundColor || STICKY_NOTE_DEFAULT_COLOR,
+        fillStyle: opts.fillStyle || "solid",
+        roughness: 0,
+        roundness: { type: 3 as const, value: STICKY_NOTE_CORNER_RADIUS },
+      }),
+      text,
+      originalText: opts.originalText ?? text,
+      fontSize,
+      fontFamily,
+      textAlign: opts.textAlign || "center",
+      verticalAlign: opts.verticalAlign || "middle",
+      lineHeight,
+    },
+    {},
+  );
 };

--- a/packages/element/src/renderElement.ts
+++ b/packages/element/src/renderElement.ts
@@ -78,6 +78,7 @@ import type {
   ExcalidrawFrameLikeElement,
   NonDeletedSceneElementsMap,
   ElementsMap,
+  ExcalidrawStickyNoteElement,
 } from "./types";
 
 import type { RoughCanvas } from "roughjs/bin/canvas";
@@ -384,6 +385,117 @@ const drawImagePlaceholder = (
   );
 };
 
+const STICKY_NOTE_PADDING = 16;
+
+const drawStickyNoteOnCanvas = (
+  element: ExcalidrawStickyNoteElement,
+  context: CanvasRenderingContext2D,
+  renderConfig: StaticCanvasRenderConfig,
+) => {
+  const { width, height } = element;
+  const radius = getCornerRadius(Math.min(width, height), element);
+  const bgColor =
+    renderConfig.theme === THEME.DARK
+      ? applyDarkModeFilter(element.backgroundColor)
+      : element.backgroundColor;
+  const strokeColor =
+    renderConfig.theme === THEME.DARK
+      ? applyDarkModeFilter(element.strokeColor)
+      : element.strokeColor;
+
+  context.save();
+
+  context.shadowColor = "rgba(0, 0, 0, 0.15)";
+  context.shadowBlur = 8;
+  context.shadowOffsetX = 2;
+  context.shadowOffsetY = 3;
+
+  context.beginPath();
+  if (context.roundRect) {
+    context.roundRect(0, 0, width, height, radius);
+  } else {
+    context.moveTo(radius, 0);
+    context.lineTo(width - radius, 0);
+    context.quadraticCurveTo(width, 0, width, radius);
+    context.lineTo(width, height - radius);
+    context.quadraticCurveTo(width, height, width - radius, height);
+    context.lineTo(radius, height);
+    context.quadraticCurveTo(0, height, 0, height - radius);
+    context.lineTo(0, radius);
+    context.quadraticCurveTo(0, 0, radius, 0);
+    context.closePath();
+  }
+
+  context.fillStyle = bgColor;
+  context.fill();
+
+  context.shadowColor = "transparent";
+  context.shadowBlur = 0;
+  context.shadowOffsetX = 0;
+  context.shadowOffsetY = 0;
+
+  if (element.strokeWidth > 0 && strokeColor !== "transparent") {
+    context.strokeStyle = strokeColor;
+    context.lineWidth = element.strokeWidth;
+    if (element.strokeStyle === "dashed") {
+      context.setLineDash([8, 8 + element.strokeWidth]);
+    } else if (element.strokeStyle === "dotted") {
+      context.setLineDash([1.5, 6 + element.strokeWidth]);
+    }
+    context.stroke();
+  }
+
+  if (element.text) {
+    const rtl = isRTL(element.text);
+    context.canvas.setAttribute("dir", rtl ? "rtl" : "ltr");
+    context.font = getFontString(element);
+    context.fillStyle =
+      renderConfig.theme === THEME.DARK
+        ? applyDarkModeFilter(element.strokeColor)
+        : element.strokeColor;
+    context.textAlign = element.textAlign as CanvasTextAlign;
+    context.textBaseline = "top";
+
+    const lines = element.text.replace(/\r\n?/g, "\n").split("\n");
+    const lineHeightPx = getLineHeightInPx(
+      element.fontSize,
+      element.lineHeight,
+    );
+    const verticalOffset = getVerticalOffset(
+      element.fontFamily,
+      element.fontSize,
+      lineHeightPx,
+    );
+
+    const textBlockHeight = lines.length * lineHeightPx;
+    let startY: number;
+    if (element.verticalAlign === "middle") {
+      startY = (height - textBlockHeight) / 2;
+    } else if (element.verticalAlign === "bottom") {
+      startY = height - textBlockHeight - STICKY_NOTE_PADDING;
+    } else {
+      startY = STICKY_NOTE_PADDING;
+    }
+
+    const horizontalOffset =
+      element.textAlign === "center"
+        ? width / 2
+        : element.textAlign === "right"
+        ? width - STICKY_NOTE_PADDING
+        : STICKY_NOTE_PADDING;
+
+    for (let index = 0; index < lines.length; index++) {
+      context.fillText(
+        lines[index],
+        horizontalOffset,
+        startY + index * lineHeightPx + verticalOffset,
+      );
+    }
+  }
+
+  context.restore();
+};
+
 const drawElementOnCanvas = (
   element: NonDeletedExcalidrawElement,
   rc: RoughCanvas,
@@ -541,6 +653,10 @@ const drawElementOnCanvas = (
         drawImagePlaceholder(element, context, renderConfig.theme);
       }
       context.restore();
+      break;
+    }
+    case "stickyNote": {
+      drawStickyNoteOnCanvas(element, context, renderConfig);
       break;
     }
     default: {
@@ -886,7 +1002,8 @@ export const renderElement = (
     case "image":
     case "text":
     case "iframe":
-    case "embeddable": {
+    case "embeddable":
+    case "stickyNote": {
       if (renderConfig.isExporting) {
         const [x1, y1, x2, y2] = getElementAbsoluteCoords(element, elementsMap);
         const cx = (x1 + x2) / 2 + appState.scrollX;

--- a/packages/element/src/shape.ts
+++ b/packages/element/src/shape.ts
@@ -860,7 +860,8 @@ const _generateElementShape = (
     case "frame":
     case "magicframe":
     case "text":
-    case "image": {
+    case "image":
+    case "stickyNote": {
       const shape: ElementShapes[typeof element.type] = null;
       // we return (and cache) `null` to make sure we don't regenerate
       // `element.canvas` on rerenders
@@ -959,6 +960,7 @@ export const getElementShape = <Point extends GlobalPoint | LocalPoint>(
     case "iframe":
     case "text":
     case "selection":
+    case "stickyNote":
       return getPolygonShape(element);
     case "arrow":
     case "line": {

--- a/packages/element/src/typeChecks.ts
+++ b/packages/element/src/typeChecks.ts
@@ -29,6 +29,7 @@ import type {
   ExcalidrawLineElement,
   ExcalidrawFlowchartNodeElement,
   ExcalidrawLinearElementSubType,
+  ExcalidrawStickyNoteElement,
 } from "./types";
 
 export const isInitializedImageElement = (
@@ -67,6 +68,12 @@ export const isTextElement = (
   element: ExcalidrawElement | null,
 ): element is ExcalidrawTextElement => {
   return element != null && element.type === "text";
+};
+
+export const isStickyNoteElement = (
+  element: ExcalidrawElement | null,
+): element is ExcalidrawStickyNoteElement => {
+  return element != null && element.type === "stickyNote";
 };
 
 export const isFrameElement = (
@@ -189,6 +196,7 @@ export const isBindableElement = (
       element.type === "embeddable" ||
       element.type === "frame" ||
       element.type === "magicframe" ||
+      element.type === "stickyNote" ||
       (element.type === "text" && !element.containerId))
   );
 };
@@ -205,6 +213,7 @@ export const isRectanguloidElement = (
       element.type === "embeddable" ||
       element.type === "frame" ||
       element.type === "magicframe" ||
+      element.type === "stickyNote" ||
       (element.type === "text" && !element.containerId))
   );
 };
@@ -223,7 +232,8 @@ export const isRectangularElement = (
       element.type === "embeddable" ||
       element.type === "frame" ||
       element.type === "magicframe" ||
-      element.type === "freedraw")
+      element.type === "freedraw" ||
+      element.type === "stickyNote")
   );
 };
 
@@ -261,7 +271,8 @@ export const isExcalidrawElement = (
     case "frame":
     case "magicframe":
     case "image":
-    case "selection": {
+    case "selection":
+    case "stickyNote": {
       return true;
     }
     default: {
@@ -309,7 +320,8 @@ export const isUsingAdaptiveRadius = (type: string) =>
   type === "rectangle" ||
   type === "embeddable" ||
   type === "iframe" ||
-  type === "image";
+  type === "image" ||
+  type === "stickyNote";
 
 export const isUsingProportionalRadius = (type: string) =>
   type === "line" || type === "arrow" || type === "diamond";

--- a/packages/element/src/types.ts
+++ b/packages/element/src/types.ts
@@ -102,6 +102,18 @@ export type ExcalidrawEmbeddableElement = _ExcalidrawElementBase &
     type: "embeddable";
   }>;
 
+export type ExcalidrawStickyNoteElement = _ExcalidrawElementBase &
+  Readonly<{
+    type: "stickyNote";
+    text: string;
+    originalText: string;
+    fontSize: number;
+    fontFamily: FontFamilyValues;
+    textAlign: TextAlign;
+    verticalAlign: VerticalAlign;
+    lineHeight: number & { _brand: "unitlessLineHeight" };
+  }>;
+
 export type MagicGenerationData =
   | {
       status: "pending";
@@ -196,7 +208,8 @@ export type ExcalidrawRectanguloidElement =
   | ExcalidrawIframeLikeElement
   | ExcalidrawFrameLikeElement
   | ExcalidrawEmbeddableElement
-  | ExcalidrawSelectionElement;
+  | ExcalidrawSelectionElement
+  | ExcalidrawStickyNoteElement;
 
 /**
  * ExcalidrawElement should be JSON serializable and (eventually) contain
@@ -213,7 +226,8 @@ export type ExcalidrawElement =
   | ExcalidrawFrameElement
   | ExcalidrawMagicFrameElement
   | ExcalidrawIframeElement
-  | ExcalidrawEmbeddableElement;
+  | ExcalidrawEmbeddableElement
+  | ExcalidrawStickyNoteElement;
 
 export type ExcalidrawNonSelectionElement = Exclude<
   ExcalidrawElement,
@@ -265,7 +279,8 @@ export type ExcalidrawBindableElement =
   | ExcalidrawIframeElement
   | ExcalidrawEmbeddableElement
   | ExcalidrawFrameElement
-  | ExcalidrawMagicFrameElement;
+  | ExcalidrawMagicFrameElement
+  | ExcalidrawStickyNoteElement;
 
 export type ExcalidrawTextContainer =
   | ExcalidrawRectangleElement

--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -133,6 +133,7 @@ import {
   newImageElement,
   newLinearElement,
   newTextElement,
+  newStickyNoteElement,
   refreshTextDimensions,
   deepCopyElement,
   duplicateElements,
@@ -156,6 +157,7 @@ import {
   isFlowchartNodeElement,
   isBindableElement,
   isTextElement,
+  isStickyNoteElement,
   getNormalizedDimensions,
   isElementCompletelyInViewport,
   isElementInViewport,
@@ -279,6 +281,7 @@ import type {
   IframeData,
   ExcalidrawIframeElement,
   ExcalidrawEmbeddableElement,
+  ExcalidrawStickyNoteElement,
   Ordered,
   MagicGenerationData,
   ExcalidrawArrowElement,
@@ -6190,6 +6193,11 @@ class App extends React.Component<AppProps, AppState> {
     if (!event[KEYS.CTRL_OR_CMD] && !this.state.viewModeEnabled) {
       const hitElement = this.getElementAtPosition(sceneX, sceneY);
 
+      if (isStickyNoteElement(hitElement)) {
+        this.startStickyNoteEditing(hitElement);
+        return;
+      }
+
       if (isIframeLikeElement(hitElement)) {
         this.setState({
           activeEmbeddable: { element: hitElement, state: "active" },
@@ -7521,6 +7529,8 @@ class App extends React.Component<AppProps, AppState> {
         pointerDownState.lastCoords.x,
         pointerDownState.lastCoords.y,
       );
+    } else if (this.state.activeTool.type === "stickyNote") {
+      this.handleStickyNoteOnPointerDown(pointerDownState);
     } else if (
       this.state.activeTool.type !== "eraser" &&
       this.state.activeTool.type !== "hand" &&
@@ -8418,6 +8428,187 @@ class App extends React.Component<AppProps, AppState> {
         }),
       });
     }
+  };
+
+  private handleStickyNoteOnPointerDown = (
+    pointerDownState: PointerDownState,
+  ): void => {
+    if (this.state.editingTextElement) {
+      return;
+    }
+
+    const [gridX, gridY] = getGridPoint(
+      pointerDownState.origin.x,
+      pointerDownState.origin.y,
+      this.lastPointerDownEvent?.[KEYS.CTRL_OR_CMD]
+        ? null
+        : this.getEffectiveGridSize(),
+    );
+
+    const topLayerFrame = this.getTopLayerFrameAtSceneCoords({
+      x: gridX,
+      y: gridY,
+    });
+
+    const stickyNote = newStickyNoteElement({
+      x: gridX - 100,
+      y: gridY - 100,
+      strokeColor: this.state.currentItemStrokeColor,
+      backgroundColor:
+        this.state.currentItemBackgroundColor === "transparent"
+          ? undefined
+          : this.state.currentItemBackgroundColor,
+      fillStyle: this.state.currentItemFillStyle,
+      strokeWidth: this.state.currentItemStrokeWidth,
+      strokeStyle: this.state.currentItemStrokeStyle,
+      opacity: this.state.currentItemOpacity,
+      fontSize: this.state.currentItemFontSize,
+      fontFamily: this.state.currentItemFontFamily,
+      locked: false,
+      frameId: topLayerFrame ? topLayerFrame.id : null,
+    });
+
+    this.scene.insertElement(stickyNote);
+
+    this.setState({
+      newElement: null,
+      selectedElementIds: makeNextSelectedElementIds(
+        { [stickyNote.id]: true },
+        this.state,
+      ),
+    });
+
+    this.startStickyNoteEditing(stickyNote);
+
+    resetCursor(this.interactiveCanvas);
+    if (!this.state.activeTool.locked) {
+      this.setState({
+        activeTool: updateActiveTool(this.state, {
+          type: this.state.preferredSelectionTool.type,
+        }),
+      });
+    }
+  };
+
+  private startStickyNoteEditing = (element: ExcalidrawStickyNoteElement) => {
+    this.setState({ editingTextElement: element as any });
+
+    const PADDING = 16;
+
+    const updateStickyNoteText = (nextText: string, isDeleted?: boolean) => {
+      this.scene.replaceAllElements(
+        this.scene.getElementsIncludingDeleted().map((_element) => {
+          if (_element.id === element.id && isStickyNoteElement(_element)) {
+            return newElementWith(_element, {
+              originalText: nextText,
+              text: nextText,
+              ...(isDeleted != null ? { isDeleted } : {}),
+            });
+          }
+          return _element;
+        }),
+      );
+    };
+
+    const { x: viewportX, y: viewportY } = sceneCoordsToViewportCoords(
+      { sceneX: element.x, sceneY: element.y },
+      this.state,
+    );
+    const viewX = viewportX - this.state.offsetLeft;
+    const viewY = viewportY - this.state.offsetTop;
+    const zoom = this.state.zoom.value;
+
+    const width = element.width - PADDING * 2;
+    const height = element.height - PADDING * 2;
+    const translateX = (width * (zoom - 1)) / 2;
+    const translateY = (height * (zoom - 1)) / 2;
+
+    const textarea = document.createElement("textarea");
+    textarea.value = element.originalText;
+    textarea.className = "excalidraw-wysiwyg";
+
+    Object.assign(textarea.style, {
+      position: "absolute",
+      left: `${viewX + PADDING * zoom}px`,
+      top: `${viewY + PADDING * zoom}px`,
+      width: `${width}px`,
+      height: `${height}px`,
+      transform: `translate(${translateX}px, ${translateY}px) scale(${zoom})`,
+      transformOrigin: "top left",
+      font: getFontString(element),
+      lineHeight: `${element.lineHeight}`,
+      textAlign: element.textAlign,
+      color: element.strokeColor,
+      background: "transparent",
+      border: "none",
+      outline: "none",
+      resize: "none",
+      overflow: "hidden",
+      wordBreak: "break-word",
+      whiteSpace: "pre-wrap",
+      boxSizing: "border-box",
+      zIndex: "100",
+      padding: "0",
+      margin: "0",
+    });
+    textarea.dir = "auto";
+
+    const container = this.excalidrawContainerRef.current;
+    if (container) {
+      container.appendChild(textarea);
+    } else {
+      document.body.appendChild(textarea);
+    }
+
+    setTimeout(() => {
+      textarea.focus();
+      textarea.select();
+    }, 0);
+
+    const handleSubmit = () => {
+      const text = textarea.value.trim();
+      updateStickyNoteText(text);
+      textarea.remove();
+      this.setState({
+        editingTextElement: null,
+      });
+
+      if (text) {
+        this.setState((prevState) => ({
+          selectedElementIds: makeNextSelectedElementIds(
+            { [element.id]: true },
+            prevState,
+          ),
+        }));
+        this.store.scheduleCapture();
+      }
+
+      this.focusContainer();
+    };
+
+    textarea.addEventListener("blur", handleSubmit);
+    textarea.addEventListener("keydown", (e) => {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        e.stopPropagation();
+        textarea.removeEventListener("blur", handleSubmit);
+        const text = textarea.value.trim();
+        updateStickyNoteText(text);
+        textarea.remove();
+        this.setState({ editingTextElement: null });
+        this.focusContainer();
+      }
+      if (e.key === "Tab") {
+        e.preventDefault();
+        const start = textarea.selectionStart;
+        const end = textarea.selectionEnd;
+        textarea.value = `${textarea.value.substring(
+          0,
+          start,
+        )}  ${textarea.value.substring(end)}`;
+        textarea.selectionStart = textarea.selectionEnd = start + 2;
+      }
+    });
   };
 
   private handleFreeDrawElementOnPointerDown = (

--- a/packages/excalidraw/components/icons.tsx
+++ b/packages/excalidraw/components/icons.tsx
@@ -333,6 +333,25 @@ export const RectangleIcon = createIcon(
   tablerIconProps,
 );
 
+export const StickyNoteIcon = createIcon(
+  <g strokeWidth="1.5">
+    <path stroke="none" d="M0 0h24v24H0z" fill="none" />
+    <path
+      d="M5 4h14a1 1 0 0 1 1 1v9.5l-5.5 5.5H5a1 1 0 0 1-1-4V5a1 1 0 0 1 1-1z"
+      fill="#FDEFA3"
+      stroke="currentColor"
+    />
+    <path
+      d="M14.5 14.5V20L20 14.5H14.5z"
+      fill="#F5DF8E"
+      stroke="currentColor"
+    />
+    <line x1="8" y1="9" x2="13" y2="9" />
+    <line x1="8" y1="13" x2="12" y2="13" />
+  </g>,
+  tablerIconProps,
+);
+
 // tabler-icons: square-rotated
 export const DiamondIcon = createIcon(
   <g strokeWidth="1.5">

--- a/packages/excalidraw/components/shapes.tsx
+++ b/packages/excalidraw/components/shapes.tsx
@@ -13,6 +13,7 @@ import {
   EraserIcon,
   laserPointerToolIcon,
   handIcon,
+  StickyNoteIcon,
 } from "./icons";
 
 import type { AppClassProperties } from "../types";
@@ -88,6 +89,14 @@ export const SHAPES = [
     key: KEYS.T,
     numericKey: KEYS["8"],
     fillable: false,
+    toolbar: true,
+  },
+  {
+    icon: StickyNoteIcon,
+    value: "stickyNote",
+    key: KEYS.S,
+    numericKey: null,
+    fillable: true,
     toolbar: true,
   },
   {

--- a/packages/excalidraw/data/restore.ts
+++ b/packages/excalidraw/data/restore.ts
@@ -3,6 +3,7 @@ import { isFiniteNumber, pointFrom } from "@excalidraw/math";
 import {
   type CombineBrandsIfNeeded,
   DEFAULT_FONT_FAMILY,
+  DEFAULT_FONT_SIZE,
   DEFAULT_TEXT_ALIGN,
   DEFAULT_VERTICAL_ALIGN,
   FONT_FAMILY,
@@ -116,6 +117,7 @@ export const AllowedExcalidrawActiveTools: Record<
   hand: true,
   laser: false,
   magicframe: false,
+  stickyNote: true,
 };
 
 export type RestoredDataState = {
@@ -524,6 +526,18 @@ export const restoreElement = (
     case "frame":
       return restoreElementWithProperties(element, {
         name: element.name ?? null,
+      });
+    case "stickyNote":
+      return restoreElementWithProperties(element, {
+        text: element.text || "",
+        originalText: element.originalText || element.text || "",
+        fontSize: element.fontSize || DEFAULT_FONT_SIZE,
+        fontFamily: element.fontFamily || DEFAULT_FONT_FAMILY,
+        textAlign: element.textAlign || "center",
+        verticalAlign: element.verticalAlign || "middle",
+        lineHeight:
+          element.lineHeight ||
+          getLineHeight(element.fontFamily || DEFAULT_FONT_FAMILY),
       });
 
     // Don't use default case so as to catch a missing an element type case.

--- a/packages/excalidraw/locales/en.json
+++ b/packages/excalidraw/locales/en.json
@@ -317,6 +317,7 @@
     "embeddable": "Web Embed",
     "laser": "Laser pointer",
     "hand": "Hand (panning tool)",
+    "stickyNote": "Sticky Note",
     "extraTools": "More tools",
     "mermaidToExcalidraw": "Mermaid to Excalidraw",
     "convertElementType": "Toggle shape type"
@@ -335,7 +336,8 @@
     "magicframe": "Wireframe to code",
     "embeddable": "Web Embed",
     "selection": "Selection",
-    "iframe": "IFrame"
+    "iframe": "IFrame",
+    "stickyNote": "Sticky Note"
   },
   "headings": {
     "canvasActions": "Canvas actions",

--- a/packages/excalidraw/scene/types.ts
+++ b/packages/excalidraw/scene/types.ts
@@ -172,4 +172,5 @@ export type ElementShapes = {
   image: null;
   frame: null;
   magicframe: null;
+  stickyNote: null;
 };

--- a/packages/excalidraw/tests/helpers/api.ts
+++ b/packages/excalidraw/tests/helpers/api.ts
@@ -17,6 +17,7 @@ import {
   newLinearElement,
   newMagicFrameElement,
   newTextElement,
+  newStickyNoteElement,
 } from "@excalidraw/element";
 
 import { isLinearElementType } from "@excalidraw/element";
@@ -362,6 +363,14 @@ export class API {
         break;
       case "magicframe":
         element = newMagicFrameElement({ ...base, width, height });
+        break;
+      case "stickyNote":
+        element = newStickyNoteElement({
+          ...base,
+          width,
+          height,
+          text: rest.text || "",
+        });
         break;
       default:
         assertNever(

--- a/packages/excalidraw/types.ts
+++ b/packages/excalidraw/types.ts
@@ -156,7 +156,8 @@ export type ToolType =
   | "frame"
   | "magicframe"
   | "embeddable"
-  | "laser";
+  | "laser"
+  | "stickyNote";
 
 export type ElementOrToolType = ExcalidrawElementType | ToolType | "custom";
 

--- a/packages/utils/src/shape.ts
+++ b/packages/utils/src/shape.ts
@@ -50,6 +50,7 @@ import type {
   ExcalidrawLinearElement,
   ExcalidrawRectangleElement,
   ExcalidrawSelectionElement,
+  ExcalidrawStickyNoteElement,
   ExcalidrawTextElement,
 } from "@excalidraw/element/types";
 import type { Curve, LineSegment, Polygon, Radians } from "@excalidraw/math";
@@ -110,7 +111,8 @@ type RectangularElement =
   | ExcalidrawImageElement
   | ExcalidrawIframeElement
   | ExcalidrawTextElement
-  | ExcalidrawSelectionElement;
+  | ExcalidrawSelectionElement
+  | ExcalidrawStickyNoteElement;
 
 // polygon
 export const getPolygonShape = <Point extends GlobalPoint | LocalPoint>(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Implement the sticky note feature, adding a new element type with inline text to the Excalidraw shape toolbar as requested in issue #4.

---
[Slack Thread](https://cursor-demoworkspace.slack.com/archives/C0AHFD2GACT/p1772653077895839?thread_ts=1772653077.895839&cid=C0AHFD2GACT)

<p><a href="https://cursor.com/agents/bc-74f4c710-bf3e-5485-b87c-1b6ed847ba4e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-74f4c710-bf3e-5485-b87c-1b6ed847ba4e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->