### PR TITLE
feat: Add Sticky Note tool to the shape toolbar

### DIFF
--- a/.cursor/rules/excalidraw.md
+++ b/.cursor/rules/excalidraw.md
@@ -1,25 +1,33 @@
 # Excalidraw — Cursor Rules
 
 ## Commands
+
 <!-- Build, test, lint commands -->
+
 - `yarn test:typecheck` — TypeScript check
 - `yarn test:app --watch=false` — run all tests
 - `yarn fix` — Prettier + ESLint auto-fix
 
 ## Code Style
+
 <!-- Conventions and patterns -->
+
 - ESLint + Prettier via `@excalidraw/*` configs
 - Use package aliases: `@excalidraw/common`, `@excalidraw/element`, `@excalidraw/math`
 - Tests use `describe`/`it` with `@testing-library/react`
 
 ## Architecture
+
 <!-- Where things go -->
+
 - Monorepo: `packages/*`, `excalidraw-app/`, `examples/`
 - Editor features → `packages/excalidraw/`
 - Tests colocate next to source as `*.test.{ts,tsx}`
 
 ## Workflow
+
 <!-- What the agent should always do -->
+
 - Run `yarn test:typecheck` before committing
 - Run `yarn test:app --watch=false` before committing
 - Run `yarn fix` to auto-format

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@ Excalidraw is a client-side whiteboard/diagramming React app. The only service r
 ### Services
 
 | Service | Command | Port | Notes |
-|---|---|---|---|
+| --- | --- | --- | --- |
 | Vite dev server | `yarn start` | 3001 | The main app; core drawing works fully offline with no backends |
 
 ### Development commands

--- a/packages/common/src/constants.ts
+++ b/packages/common/src/constants.ts
@@ -461,6 +461,7 @@ export const TOOL_TYPE = {
   magicframe: "magicframe",
   embeddable: "embeddable",
   laser: "laser",
+  stickyNote: "stickyNote",
 } as const;
 
 export const EDITOR_LS_KEYS = {

--- a/packages/element/src/bounds.ts
+++ b/packages/element/src/bounds.ts
@@ -429,6 +429,7 @@ const _isRectanguloidElement = (
       element.type === "embeddable" ||
       element.type === "frame" ||
       element.type === "magicframe" ||
+      element.type === "stickyNote" ||
       (element.type === "text" && !element.containerId))
   );
 };

--- a/packages/element/src/collision.ts
+++ b/packages/element/src/collision.ts
@@ -440,6 +440,7 @@ export const intersectElementWithLineSegment = (
     case "frame":
     case "selection":
     case "magicframe":
+    case "stickyNote":
       return intersectRectanguloidWithLineSegment(
         element,
         elementsMap,

--- a/packages/element/src/comparisons.ts
+++ b/packages/element/src/comparisons.ts
@@ -7,7 +7,8 @@ export const hasBackground = (type: ElementOrToolType) =>
   type === "ellipse" ||
   type === "diamond" ||
   type === "line" ||
-  type === "freedraw";
+  type === "freedraw" ||
+  type === "stickyNote";
 
 export const hasStrokeColor = (type: ElementOrToolType) =>
   type === "rectangle" ||
@@ -17,7 +18,8 @@ export const hasStrokeColor = (type: ElementOrToolType) =>
   type === "arrow" ||
   type === "line" ||
   type === "text" ||
-  type === "embeddable";
+  type === "embeddable" ||
+  type === "stickyNote";
 
 export const hasStrokeWidth = (type: ElementOrToolType) =>
   type === "rectangle" ||
@@ -27,7 +29,8 @@ export const hasStrokeWidth = (type: ElementOrToolType) =>
   type === "diamond" ||
   type === "freedraw" ||
   type === "arrow" ||
-  type === "line";
+  type === "line" ||
+  type === "stickyNote";
 
 export const hasStrokeStyle = (type: ElementOrToolType) =>
   type === "rectangle" ||
@@ -36,7 +39,8 @@ export const hasStrokeStyle = (type: ElementOrToolType) =>
   type === "ellipse" ||
   type === "diamond" ||
   type === "arrow" ||
-  type === "line";
+  type === "line" ||
+  type === "stickyNote";
 
 export const canChangeRoundness = (type: ElementOrToolType) =>
   type === "rectangle" ||

--- a/packages/element/src/distance.ts
+++ b/packages/element/src/distance.ts
@@ -40,6 +40,7 @@ export const distanceToElement = (
     case "embeddable":
     case "frame":
     case "magicframe":
+    case "stickyNote":
       return distanceToRectanguloidElement(element, elementsMap, p);
     case "diamond":
       return distanceToDiamondElement(element, elementsMap, p);

--- a/packages/element/src/mutateElement.ts
+++ b/packages/element/src/mutateElement.ts
@@ -129,7 +129,9 @@ export const mutateElement = <TElement extends Mutable<ExcalidrawElement>>(
     typeof updates.height !== "undefined" ||
     typeof updates.width !== "undefined" ||
     typeof fileId != "undefined" ||
-    typeof points !== "undefined"
+    typeof points !== "undefined" ||
+    (element.type === "stickyNote" &&
+      typeof (updates as any).text !== "undefined")
   ) {
     ShapeCache.delete(element);
   }

--- a/packages/element/src/newElement.ts
+++ b/packages/element/src/newElement.ts
@@ -549,8 +549,7 @@ export const newStickyNoteElement = (
   return {
     ..._newElementBase<ExcalidrawStickyNoteElement>("stickyNote", {
       ...opts,
-      backgroundColor:
-        opts.backgroundColor || STICKY_NOTE_DEFAULT_COLOR,
+      backgroundColor: opts.backgroundColor || STICKY_NOTE_DEFAULT_COLOR,
       fillStyle: opts.fillStyle || "solid",
       strokeWidth: opts.strokeWidth ?? 1,
       roughness: opts.roughness ?? 0,

--- a/packages/element/src/newElement.ts
+++ b/packages/element/src/newElement.ts
@@ -48,6 +48,7 @@ import type {
   ExcalidrawArrowElement,
   ExcalidrawElbowArrowElement,
   ExcalidrawLineElement,
+  ExcalidrawStickyNoteElement,
 } from "./types";
 
 export type ElementConstructorOpts = MarkOptional<
@@ -522,6 +523,50 @@ export const newArrowElement = <T extends boolean>(
   } as T extends true
     ? NonDeleted<ExcalidrawElbowArrowElement>
     : NonDeleted<ExcalidrawArrowElement>;
+};
+
+export const STICKY_NOTE_DEFAULT_WIDTH = 200;
+export const STICKY_NOTE_DEFAULT_HEIGHT = 200;
+export const STICKY_NOTE_DEFAULT_COLOR = "#FDEFA3";
+
+export const newStickyNoteElement = (
+  opts: {
+    text?: string;
+    fontSize?: number;
+    fontFamily?: FontFamilyValues;
+    textAlign?: TextAlign;
+    verticalAlign?: VerticalAlign;
+    lineHeight?: ExcalidrawStickyNoteElement["lineHeight"];
+  } & ElementConstructorOpts,
+): NonDeleted<ExcalidrawStickyNoteElement> => {
+  const fontFamily = opts.fontFamily || DEFAULT_FONT_FAMILY;
+  const fontSize = opts.fontSize || DEFAULT_FONT_SIZE;
+  const lineHeight = opts.lineHeight || getLineHeight(fontFamily);
+  const text = normalizeText(opts.text || "");
+  const textAlign = opts.textAlign || "center";
+  const verticalAlign = opts.verticalAlign || VERTICAL_ALIGN.MIDDLE;
+
+  return {
+    ..._newElementBase<ExcalidrawStickyNoteElement>("stickyNote", {
+      ...opts,
+      backgroundColor:
+        opts.backgroundColor || STICKY_NOTE_DEFAULT_COLOR,
+      fillStyle: opts.fillStyle || "solid",
+      strokeWidth: opts.strokeWidth ?? 1,
+      roughness: opts.roughness ?? 0,
+      roundness: opts.roundness ?? { type: 3, value: 10 },
+      width: opts.width || STICKY_NOTE_DEFAULT_WIDTH,
+      height: opts.height || STICKY_NOTE_DEFAULT_HEIGHT,
+    }),
+    text,
+    fontSize,
+    fontFamily,
+    textAlign,
+    verticalAlign,
+    originalText: text,
+    lineHeight,
+    autoResize: false,
+  };
 };
 
 export const newImageElement = (

--- a/packages/element/src/renderElement.ts
+++ b/packages/element/src/renderElement.ts
@@ -62,7 +62,6 @@ import {
   hasBoundTextElement,
   isMagicFrameElement,
   isImageElement,
-  isStickyNoteElement,
 } from "./typeChecks";
 import { getContainingFrame } from "./frame";
 import { getCornerRadius } from "./utils";
@@ -79,7 +78,6 @@ import type {
   ExcalidrawFrameLikeElement,
   NonDeletedSceneElementsMap,
   ElementsMap,
-  ExcalidrawStickyNoteElement,
 } from "./types";
 
 import type { RoughCanvas } from "roughjs/bin/canvas";

--- a/packages/element/src/renderElement.ts
+++ b/packages/element/src/renderElement.ts
@@ -62,6 +62,7 @@ import {
   hasBoundTextElement,
   isMagicFrameElement,
   isImageElement,
+  isStickyNoteElement,
 } from "./typeChecks";
 import { getContainingFrame } from "./frame";
 import { getCornerRadius } from "./utils";
@@ -78,6 +79,7 @@ import type {
   ExcalidrawFrameLikeElement,
   NonDeletedSceneElementsMap,
   ElementsMap,
+  ExcalidrawStickyNoteElement,
 } from "./types";
 
 import type { RoughCanvas } from "roughjs/bin/canvas";
@@ -400,6 +402,93 @@ const drawElementOnCanvas = (
       context.lineCap = "round";
 
       rc.draw(ShapeCache.generateElementShape(element, renderConfig));
+      break;
+    }
+    case "stickyNote": {
+      context.lineJoin = "round";
+      context.lineCap = "round";
+
+      context.save();
+      context.shadowColor = "rgba(0, 0, 0, 0.15)";
+      context.shadowBlur = 8;
+      context.shadowOffsetX = 2;
+      context.shadowOffsetY = 3;
+      rc.draw(ShapeCache.generateElementShape(element, renderConfig));
+      context.restore();
+
+      if (element.text) {
+        context.save();
+        const padding = 10;
+        context.font = getFontString({
+          fontSize: element.fontSize,
+          fontFamily: element.fontFamily,
+        });
+        context.fillStyle =
+          renderConfig.theme === THEME.DARK
+            ? applyDarkModeFilter(element.strokeColor)
+            : element.strokeColor;
+        context.textAlign = element.textAlign as CanvasTextAlign;
+        context.textBaseline = "top";
+
+        const maxWidth = element.width - padding * 2;
+        const lineHeightPx = getLineHeightInPx(
+          element.fontSize,
+          element.lineHeight,
+        );
+        const lines = element.text.replace(/\r\n?/g, "\n").split("\n");
+
+        const horizontalOffset =
+          element.textAlign === "center"
+            ? element.width / 2
+            : element.textAlign === "right"
+            ? element.width - padding
+            : padding;
+
+        const totalTextHeight = lines.length * lineHeightPx;
+        let startY: number;
+        if (element.verticalAlign === "middle") {
+          startY = (element.height - totalTextHeight) / 2;
+        } else if (element.verticalAlign === "bottom") {
+          startY = element.height - totalTextHeight - padding;
+        } else {
+          startY = padding;
+        }
+
+        const verticalOffset = getVerticalOffset(
+          element.fontFamily,
+          element.fontSize,
+          lineHeightPx,
+        );
+
+        for (let index = 0; index < lines.length; index++) {
+          const line = lines[index];
+          const words = line.split(" ");
+          let currentLine = "";
+
+          for (const word of words) {
+            const testLine = currentLine ? `${currentLine} ${word}` : word;
+            const metrics = context.measureText(testLine);
+            if (metrics.width > maxWidth && currentLine) {
+              context.fillText(
+                currentLine,
+                horizontalOffset,
+                startY + verticalOffset,
+              );
+              startY += lineHeightPx;
+              currentLine = word;
+            } else {
+              currentLine = testLine;
+            }
+          }
+          context.fillText(
+            currentLine,
+            horizontalOffset,
+            startY + verticalOffset,
+          );
+          startY += lineHeightPx;
+        }
+        context.restore();
+      }
       break;
     }
     case "arrow":
@@ -886,7 +975,8 @@ export const renderElement = (
     case "image":
     case "text":
     case "iframe":
-    case "embeddable": {
+    case "embeddable":
+    case "stickyNote": {
       if (renderConfig.isExporting) {
         const [x1, y1, x2, y2] = getElementAbsoluteCoords(element, elementsMap);
         const cx = (x1 + x2) / 2 + appState.scrollX;

--- a/packages/element/src/shape.ts
+++ b/packages/element/src/shape.ts
@@ -230,7 +230,8 @@ export const generateRoughOptions = (
     case "iframe":
     case "embeddable":
     case "diamond":
-    case "ellipse": {
+    case "ellipse":
+    case "stickyNote": {
       options.fillStyle = element.fillStyle;
       options.fill = isTransparent(element.backgroundColor)
         ? undefined
@@ -690,6 +691,22 @@ const _generateElementShape = (
       }
       return shape;
     }
+    case "stickyNote": {
+      const w = element.width;
+      const h = element.height;
+      const r = element.roundness
+        ? getCornerRadius(Math.min(w, h), element)
+        : 10;
+      const shape: Drawable = generator.path(
+        `M ${r} 0 L ${w - r} 0 Q ${w} 0, ${w} ${r} L ${w} ${
+          h - r
+        } Q ${w} ${h}, ${w - r} ${h} L ${r} ${h} Q 0 ${h}, 0 ${
+          h - r
+        } L 0 ${r} Q 0 0, ${r} 0`,
+        generateRoughOptions(element, true, isDarkMode),
+      );
+      return shape;
+    }
     case "diamond": {
       let shape: ElementShapes[typeof element.type];
 
@@ -959,6 +976,7 @@ export const getElementShape = <Point extends GlobalPoint | LocalPoint>(
     case "iframe":
     case "text":
     case "selection":
+    case "stickyNote":
       return getPolygonShape(element);
     case "arrow":
     case "line": {

--- a/packages/element/src/typeChecks.ts
+++ b/packages/element/src/typeChecks.ts
@@ -29,7 +29,14 @@ import type {
   ExcalidrawLineElement,
   ExcalidrawFlowchartNodeElement,
   ExcalidrawLinearElementSubType,
+  ExcalidrawStickyNoteElement,
 } from "./types";
+
+export const isStickyNoteElement = (
+  element: ExcalidrawElement | null | undefined,
+): element is ExcalidrawStickyNoteElement => {
+  return !!element && element.type === "stickyNote";
+};
 
 export const isInitializedImageElement = (
   element: ExcalidrawElement | null,
@@ -189,6 +196,7 @@ export const isBindableElement = (
       element.type === "embeddable" ||
       element.type === "frame" ||
       element.type === "magicframe" ||
+      element.type === "stickyNote" ||
       (element.type === "text" && !element.containerId))
   );
 };
@@ -205,6 +213,7 @@ export const isRectanguloidElement = (
       element.type === "embeddable" ||
       element.type === "frame" ||
       element.type === "magicframe" ||
+      element.type === "stickyNote" ||
       (element.type === "text" && !element.containerId))
   );
 };
@@ -223,7 +232,8 @@ export const isRectangularElement = (
       element.type === "embeddable" ||
       element.type === "frame" ||
       element.type === "magicframe" ||
-      element.type === "freedraw")
+      element.type === "freedraw" ||
+      element.type === "stickyNote")
   );
 };
 
@@ -261,7 +271,8 @@ export const isExcalidrawElement = (
     case "frame":
     case "magicframe":
     case "image":
-    case "selection": {
+    case "selection":
+    case "stickyNote": {
       return true;
     }
     default: {
@@ -309,7 +320,8 @@ export const isUsingAdaptiveRadius = (type: string) =>
   type === "rectangle" ||
   type === "embeddable" ||
   type === "iframe" ||
-  type === "image";
+  type === "image" ||
+  type === "stickyNote";
 
 export const isUsingProportionalRadius = (type: string) =>
   type === "line" || type === "arrow" || type === "diamond";

--- a/packages/element/src/types.ts
+++ b/packages/element/src/types.ts
@@ -97,6 +97,19 @@ export type ExcalidrawEllipseElement = _ExcalidrawElementBase & {
   type: "ellipse";
 };
 
+export type ExcalidrawStickyNoteElement = _ExcalidrawElementBase &
+  Readonly<{
+    type: "stickyNote";
+    text: string;
+    fontSize: number;
+    fontFamily: FontFamilyValues;
+    textAlign: TextAlign;
+    verticalAlign: VerticalAlign;
+    originalText: string;
+    lineHeight: number & { _brand: "unitlessLineHeight" };
+    autoResize: boolean;
+  }>;
+
 export type ExcalidrawEmbeddableElement = _ExcalidrawElementBase &
   Readonly<{
     type: "embeddable";
@@ -196,7 +209,8 @@ export type ExcalidrawRectanguloidElement =
   | ExcalidrawIframeLikeElement
   | ExcalidrawFrameLikeElement
   | ExcalidrawEmbeddableElement
-  | ExcalidrawSelectionElement;
+  | ExcalidrawSelectionElement
+  | ExcalidrawStickyNoteElement;
 
 /**
  * ExcalidrawElement should be JSON serializable and (eventually) contain
@@ -213,7 +227,8 @@ export type ExcalidrawElement =
   | ExcalidrawFrameElement
   | ExcalidrawMagicFrameElement
   | ExcalidrawIframeElement
-  | ExcalidrawEmbeddableElement;
+  | ExcalidrawEmbeddableElement
+  | ExcalidrawStickyNoteElement;
 
 export type ExcalidrawNonSelectionElement = Exclude<
   ExcalidrawElement,
@@ -265,7 +280,8 @@ export type ExcalidrawBindableElement =
   | ExcalidrawIframeElement
   | ExcalidrawEmbeddableElement
   | ExcalidrawFrameElement
-  | ExcalidrawMagicFrameElement;
+  | ExcalidrawMagicFrameElement
+  | ExcalidrawStickyNoteElement;
 
 export type ExcalidrawTextContainer =
   | ExcalidrawRectangleElement

--- a/packages/excalidraw/components/App.tsx
+++ b/packages/excalidraw/components/App.tsx
@@ -133,6 +133,10 @@ import {
   newImageElement,
   newLinearElement,
   newTextElement,
+  newStickyNoteElement,
+  STICKY_NOTE_DEFAULT_WIDTH,
+  STICKY_NOTE_DEFAULT_HEIGHT,
+  STICKY_NOTE_DEFAULT_COLOR,
   refreshTextDimensions,
   deepCopyElement,
   duplicateElements,
@@ -156,6 +160,7 @@ import {
   isFlowchartNodeElement,
   isBindableElement,
   isTextElement,
+  isStickyNoteElement,
   getNormalizedDimensions,
   isElementCompletelyInViewport,
   isElementInViewport,
@@ -285,6 +290,7 @@ import type {
   ExcalidrawElbowArrowElement,
   SceneElementsMap,
   ExcalidrawBindableElement,
+  ExcalidrawStickyNoteElement,
 } from "@excalidraw/element/types";
 
 import type { Mutable, ValueOf } from "@excalidraw/common/utility-types";
@@ -6197,6 +6203,11 @@ class App extends React.Component<AppProps, AppState> {
         return;
       }
 
+      if (isStickyNoteElement(hitElement)) {
+        this.handleStickyNoteTextEditing(hitElement);
+        return;
+      }
+
       // shouldn't edit/create text when inside line editor (often false positive)
 
       if (!this.state.selectedLinearElement?.isEditing) {
@@ -7516,6 +7527,8 @@ class App extends React.Component<AppProps, AppState> {
         pointerDownState,
         this.state.activeTool.type,
       );
+    } else if (this.state.activeTool.type === "stickyNote") {
+      this.handleStickyNoteOnPointerDown(event, pointerDownState);
     } else if (this.state.activeTool.type === "laser") {
       this.laserTrails.startPath(
         pointerDownState.lastCoords.x,
@@ -8928,6 +8941,140 @@ class App extends React.Component<AppProps, AppState> {
         }
       : null;
   }
+
+  private handleStickyNoteOnPointerDown = (
+    event: React.PointerEvent<HTMLElement>,
+    pointerDownState: PointerDownState,
+  ): void => {
+    const [gridX, gridY] = getGridPoint(
+      pointerDownState.origin.x,
+      pointerDownState.origin.y,
+      this.lastPointerDownEvent?.[KEYS.CTRL_OR_CMD]
+        ? null
+        : this.getEffectiveGridSize(),
+    );
+
+    const topLayerFrame = this.getTopLayerFrameAtSceneCoords({
+      x: gridX,
+      y: gridY,
+    });
+
+    const stickyNote = newStickyNoteElement({
+      x: gridX - STICKY_NOTE_DEFAULT_WIDTH / 2,
+      y: gridY - STICKY_NOTE_DEFAULT_HEIGHT / 2,
+      strokeColor: this.state.currentItemStrokeColor,
+      backgroundColor:
+        this.state.currentItemBackgroundColor === "transparent"
+          ? STICKY_NOTE_DEFAULT_COLOR
+          : this.state.currentItemBackgroundColor,
+      fillStyle: "solid",
+      strokeWidth: this.state.currentItemStrokeWidth,
+      strokeStyle: this.state.currentItemStrokeStyle,
+      roughness: 0,
+      opacity: this.state.currentItemOpacity,
+      roundness: { type: 3, value: 10 },
+      locked: false,
+      frameId: topLayerFrame ? topLayerFrame.id : null,
+      fontSize: this.state.currentItemFontSize,
+      fontFamily: this.state.currentItemFontFamily,
+    });
+
+    this.scene.insertElement(stickyNote);
+
+    this.setState({
+      newElement: null,
+      multiElement: null,
+      selectedElementIds: {
+        ...this.state.selectedElementIds,
+        [stickyNote.id]: true,
+      },
+      editingTextElement: stickyNote,
+    });
+
+    this.handleStickyNoteTextEditing(stickyNote);
+
+    if (!this.state.activeTool.locked) {
+      this.setActiveTool({ type: "selection" });
+    }
+  };
+
+  private handleStickyNoteTextEditing = (
+    element: ExcalidrawStickyNoteElement,
+  ) => {
+    const padding = 10;
+    const updateFn = textWysiwyg({
+      id: element.id,
+      canvas: this.canvas,
+      getViewportCoords: (x, y) => {
+        const { x: viewportX, y: viewportY } = sceneCoordsToViewportCoords(
+          { sceneX: x, sceneY: y },
+          this.state,
+        );
+        return [
+          viewportX - this.state.offsetLeft,
+          viewportY - this.state.offsetTop,
+        ];
+      },
+      onChange: (nextOriginalText) => {
+        const wrappedText = wrapText(
+          nextOriginalText,
+          getFontString({
+            fontSize: element.fontSize,
+            fontFamily: element.fontFamily,
+          }),
+          element.width - padding * 2,
+        );
+        this.scene.mutateElement(element, {
+          text: wrappedText,
+          originalText: nextOriginalText,
+        });
+      },
+      onSubmit: ({ viaKeyboard, nextOriginalText }) => {
+        const wrappedText = wrapText(
+          nextOriginalText,
+          getFontString({
+            fontSize: element.fontSize,
+            fontFamily: element.fontFamily,
+          }),
+          element.width - padding * 2,
+        );
+        this.scene.mutateElement(element, {
+          text: wrappedText,
+          originalText: nextOriginalText,
+        });
+        this.setState({
+          editingTextElement: null,
+        });
+        if (nextOriginalText.trim().length === 0) {
+          this.scene.mutateElement(element, {
+            text: "",
+            originalText: "",
+          });
+        }
+      },
+      element: {
+        ...element,
+        type: "text",
+        text: element.originalText,
+        originalText: element.originalText,
+        containerId: null,
+        autoResize: false,
+        width: element.width - padding * 2,
+        height: element.height - padding * 2,
+        x: element.x + padding,
+        y: element.y + padding,
+      } as ExcalidrawTextElement,
+      excalidrawContainer: this.excalidrawContainerValue.container,
+      app: this,
+      autoSelect: true,
+    });
+
+    this.setState({
+      editingTextElement: element,
+    });
+
+    return updateFn;
+  };
 
   private createGenericElementOnPointerDown = (
     elementType: ExcalidrawGenericElement["type"] | "embeddable",

--- a/packages/excalidraw/components/icons.tsx
+++ b/packages/excalidraw/components/icons.tsx
@@ -333,6 +333,16 @@ export const RectangleIcon = createIcon(
   tablerIconProps,
 );
 
+// sticky note icon
+export const StickyNoteIcon = createIcon(
+  <g strokeWidth="1.5">
+    <path stroke="none" d="M0 0h24v24H0z" fill="none" />
+    <path d="M18 14l-4 4H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h12a2 2 0 0 1 2 2v8z" />
+    <path d="M14 14v4l4-4h-4z" />
+  </g>,
+  tablerIconProps,
+);
+
 // tabler-icons: square-rotated
 export const DiamondIcon = createIcon(
   <g strokeWidth="1.5">

--- a/packages/excalidraw/components/shapes.tsx
+++ b/packages/excalidraw/components/shapes.tsx
@@ -13,6 +13,7 @@ import {
   EraserIcon,
   laserPointerToolIcon,
   handIcon,
+  StickyNoteIcon,
 } from "./icons";
 
 import type { AppClassProperties } from "../types";
@@ -88,6 +89,14 @@ export const SHAPES = [
     key: KEYS.T,
     numericKey: KEYS["8"],
     fillable: false,
+    toolbar: true,
+  },
+  {
+    icon: StickyNoteIcon,
+    value: "stickyNote",
+    key: null,
+    numericKey: null,
+    fillable: true,
     toolbar: true,
   },
   {

--- a/packages/excalidraw/data/restore.ts
+++ b/packages/excalidraw/data/restore.ts
@@ -3,6 +3,7 @@ import { isFiniteNumber, pointFrom } from "@excalidraw/math";
 import {
   type CombineBrandsIfNeeded,
   DEFAULT_FONT_FAMILY,
+  DEFAULT_FONT_SIZE,
   DEFAULT_TEXT_ALIGN,
   DEFAULT_VERTICAL_ALIGN,
   FONT_FAMILY,
@@ -116,6 +117,7 @@ export const AllowedExcalidrawActiveTools: Record<
   hand: true,
   laser: false,
   magicframe: false,
+  stickyNote: true,
 };
 
 export type RestoredDataState = {
@@ -520,6 +522,17 @@ export const restoreElement = (
     case "iframe":
     case "embeddable":
       return restoreElementWithProperties(element, {});
+    case "stickyNote":
+      return restoreElementWithProperties(element, {
+        text: element.text || "",
+        originalText: element.originalText || element.text || "",
+        fontSize: element.fontSize || DEFAULT_FONT_SIZE,
+        fontFamily: element.fontFamily || DEFAULT_FONT_FAMILY,
+        textAlign: element.textAlign || "center",
+        verticalAlign: element.verticalAlign || "middle",
+        lineHeight: element.lineHeight || getLineHeight(element.fontFamily || DEFAULT_FONT_FAMILY),
+        autoResize: element.autoResize ?? false,
+      });
     case "magicframe":
     case "frame":
       return restoreElementWithProperties(element, {

--- a/packages/excalidraw/data/restore.ts
+++ b/packages/excalidraw/data/restore.ts
@@ -530,7 +530,9 @@ export const restoreElement = (
         fontFamily: element.fontFamily || DEFAULT_FONT_FAMILY,
         textAlign: element.textAlign || "center",
         verticalAlign: element.verticalAlign || "middle",
-        lineHeight: element.lineHeight || getLineHeight(element.fontFamily || DEFAULT_FONT_FAMILY),
+        lineHeight:
+          element.lineHeight ||
+          getLineHeight(element.fontFamily || DEFAULT_FONT_FAMILY),
         autoResize: element.autoResize ?? false,
       });
     case "magicframe":

--- a/packages/excalidraw/locales/en.json
+++ b/packages/excalidraw/locales/en.json
@@ -316,6 +316,7 @@
     "magicframe": "Wireframe to code",
     "embeddable": "Web Embed",
     "laser": "Laser pointer",
+    "stickyNote": "Sticky Note",
     "hand": "Hand (panning tool)",
     "extraTools": "More tools",
     "mermaidToExcalidraw": "Mermaid to Excalidraw",

--- a/packages/excalidraw/locales/en.json
+++ b/packages/excalidraw/locales/en.json
@@ -336,7 +336,8 @@
     "magicframe": "Wireframe to code",
     "embeddable": "Web Embed",
     "selection": "Selection",
-    "iframe": "IFrame"
+    "iframe": "IFrame",
+    "stickyNote": "Sticky Note"
   },
   "headings": {
     "canvasActions": "Canvas actions",

--- a/packages/excalidraw/renderer/staticSvgScene.ts
+++ b/packages/excalidraw/renderer/staticSvgScene.ts
@@ -177,6 +177,84 @@ const renderElementToSvg = (
       addToRoot(g || node, element);
       break;
     }
+    case "stickyNote": {
+      const shape = ShapeCache.generateElementShape(element, renderConfig);
+      const node = roughSVGDrawWithPrecision(
+        rsvg,
+        shape,
+        MAX_DECIMALS_FOR_SVG_EXPORT,
+      );
+      if (opacity !== 1) {
+        node.setAttribute("stroke-opacity", `${opacity}`);
+        node.setAttribute("fill-opacity", `${opacity}`);
+      }
+      node.setAttribute("stroke-linecap", "round");
+      node.setAttribute(
+        "transform",
+        `translate(${offsetX || 0} ${
+          offsetY || 0
+        }) rotate(${degree} ${cx} ${cy})`,
+      );
+
+      const groupEl = document.createElementNS(SVG_NS, "g");
+      groupEl.appendChild(node);
+
+      if (element.text) {
+        const textEl = document.createElementNS(SVG_NS, "text");
+        textEl.setAttribute(
+          "transform",
+          `translate(${offsetX || 0} ${
+            offsetY || 0
+          }) rotate(${degree} ${cx} ${cy})`,
+        );
+        textEl.setAttribute("font-size", `${element.fontSize}px`);
+        textEl.setAttribute("font-family", `${element.fontFamily}`);
+        textEl.setAttribute("fill", element.strokeColor);
+        textEl.setAttribute("text-anchor", element.textAlign === "center" ? "middle" : element.textAlign === "right" ? "end" : "start");
+        if (opacity !== 1) {
+          textEl.setAttribute("opacity", `${opacity}`);
+        }
+
+        const padding = 10;
+        const lines = element.text.split("\n");
+        const lineHeight = element.fontSize * element.lineHeight;
+        const totalHeight = lines.length * lineHeight;
+
+        let startY: number;
+        if (element.verticalAlign === "middle") {
+          startY = element.y + (element.height - totalHeight) / 2;
+        } else {
+          startY = element.y + padding;
+        }
+
+        const xPos =
+          element.textAlign === "center"
+            ? element.x + element.width / 2
+            : element.textAlign === "right"
+            ? element.x + element.width - padding
+            : element.x + padding;
+
+        lines.forEach((line, index) => {
+          const tspan = document.createElementNS(SVG_NS, "tspan");
+          tspan.setAttribute("x", `${xPos}`);
+          tspan.setAttribute("y", `${startY + index * lineHeight + element.fontSize}`);
+          tspan.textContent = line;
+          textEl.appendChild(tspan);
+        });
+        groupEl.appendChild(textEl);
+      }
+
+      const g = maybeWrapNodesInFrameClipPath(
+        element,
+        root,
+        [groupEl],
+        renderConfig.frameRendering,
+        elementsMap,
+      );
+
+      addToRoot(g || groupEl, element);
+      break;
+    }
     case "iframe":
     case "embeddable": {
       // render placeholder rectangle

--- a/packages/excalidraw/renderer/staticSvgScene.ts
+++ b/packages/excalidraw/renderer/staticSvgScene.ts
@@ -210,7 +210,14 @@ const renderElementToSvg = (
         textEl.setAttribute("font-size", `${element.fontSize}px`);
         textEl.setAttribute("font-family", `${element.fontFamily}`);
         textEl.setAttribute("fill", element.strokeColor);
-        textEl.setAttribute("text-anchor", element.textAlign === "center" ? "middle" : element.textAlign === "right" ? "end" : "start");
+        textEl.setAttribute(
+          "text-anchor",
+          element.textAlign === "center"
+            ? "middle"
+            : element.textAlign === "right"
+            ? "end"
+            : "start",
+        );
         if (opacity !== 1) {
           textEl.setAttribute("opacity", `${opacity}`);
         }
@@ -237,7 +244,10 @@ const renderElementToSvg = (
         lines.forEach((line, index) => {
           const tspan = document.createElementNS(SVG_NS, "tspan");
           tspan.setAttribute("x", `${xPos}`);
-          tspan.setAttribute("y", `${startY + index * lineHeight + element.fontSize}`);
+          tspan.setAttribute(
+            "y",
+            `${startY + index * lineHeight + element.fontSize}`,
+          );
           tspan.textContent = line;
           textEl.appendChild(tspan);
         });

--- a/packages/excalidraw/scene/types.ts
+++ b/packages/excalidraw/scene/types.ts
@@ -172,4 +172,5 @@ export type ElementShapes = {
   image: null;
   frame: null;
   magicframe: null;
+  stickyNote: Drawable;
 };

--- a/packages/excalidraw/snapping.ts
+++ b/packages/excalidraw/snapping.ts
@@ -1409,6 +1409,7 @@ export const isActiveToolNonLinearSnappable = (
     activeToolType === TOOL_TYPE.frame ||
     activeToolType === TOOL_TYPE.magicframe ||
     activeToolType === TOOL_TYPE.image ||
-    activeToolType === TOOL_TYPE.text
+    activeToolType === TOOL_TYPE.text ||
+    activeToolType === TOOL_TYPE.stickyNote
   );
 };

--- a/packages/excalidraw/tests/helpers/api.ts
+++ b/packages/excalidraw/tests/helpers/api.ts
@@ -17,6 +17,7 @@ import {
   newLinearElement,
   newMagicFrameElement,
   newTextElement,
+  newStickyNoteElement,
 } from "@excalidraw/element";
 
 import { isLinearElementType } from "@excalidraw/element";
@@ -362,6 +363,9 @@ export class API {
         break;
       case "magicframe":
         element = newMagicFrameElement({ ...base, width, height });
+        break;
+      case "stickyNote":
+        element = newStickyNoteElement({ ...base, width, height });
         break;
       default:
         assertNever(

--- a/packages/excalidraw/tests/selection.test.tsx
+++ b/packages/excalidraw/tests/selection.test.tsx
@@ -506,7 +506,8 @@ describe("tool locking & selection", () => {
         value !== "eraser" &&
         value !== "arrow" &&
         value !== "hand" &&
-        value !== "laser"
+        value !== "laser" &&
+        value !== "stickyNote"
       ) {
         const element = UI.createElement(value);
         expect(h.state.selectedElementIds[element.id]).not.toBe(true);

--- a/packages/excalidraw/types.ts
+++ b/packages/excalidraw/types.ts
@@ -156,7 +156,8 @@ export type ToolType =
   | "frame"
   | "magicframe"
   | "embeddable"
-  | "laser";
+  | "laser"
+  | "stickyNote";
 
 export type ElementOrToolType = ExcalidrawElementType | ToolType | "custom";
 

--- a/packages/excalidraw/wysiwyg/textWysiwyg.tsx
+++ b/packages/excalidraw/wysiwyg/textWysiwyg.tsx
@@ -39,6 +39,7 @@ import {
   isArrowElement,
   isBoundToContainer,
   isTextElement,
+  isStickyNoteElement,
 } from "@excalidraw/element";
 
 import type {
@@ -146,11 +147,57 @@ export const textWysiwyg = ({
     LAST_THEME = app.state.theme;
 
     const appState = app.state;
-    const updatedTextElement = app.scene.getElement<ExcalidrawTextElement>(id);
+    const sceneElement = app.scene.getElement(id);
 
-    if (!updatedTextElement) {
+    if (!sceneElement) {
       return;
     }
+
+    if (isStickyNoteElement(sceneElement)) {
+      const stickyPadding = 10;
+      const coordX = sceneElement.x + stickyPadding;
+      const coordY = sceneElement.y + stickyPadding;
+      const width = sceneElement.width - stickyPadding * 2;
+      const height = sceneElement.height - stickyPadding * 2;
+      const [viewportX, viewportY] = getViewportCoords(coordX, coordY);
+      const font = getFontString({
+        fontSize: sceneElement.fontSize,
+        fontFamily: sceneElement.fontFamily,
+      });
+      const editorMaxHeight =
+        (appState.height - viewportY) / appState.zoom.value;
+      Object.assign(editable.style, {
+        font,
+        lineHeight: sceneElement.lineHeight,
+        width: `${width}px`,
+        height: `${height}px`,
+        left: `${viewportX}px`,
+        top: `${viewportY}px`,
+        transform: getTransform(
+          width,
+          height,
+          sceneElement.angle,
+          appState,
+          width,
+          editorMaxHeight,
+        ),
+        textAlign: sceneElement.textAlign,
+        verticalAlign: sceneElement.verticalAlign,
+        color:
+          appState.theme === THEME.DARK
+            ? applyDarkModeFilter(sceneElement.strokeColor)
+            : sceneElement.strokeColor,
+        opacity: sceneElement.opacity / 100,
+        maxHeight: `${editorMaxHeight}px`,
+      });
+      editable.scrollTop = 0;
+      if (isTestEnv()) {
+        editable.style.fontFamily = getFontFamilyString(sceneElement);
+      }
+      return;
+    }
+
+    const updatedTextElement = sceneElement as ExcalidrawTextElement;
     const { textAlign, verticalAlign } = updatedTextElement;
     const elementsMap = app.scene.getNonDeletedElementsMap();
     if (updatedTextElement && isTextElement(updatedTextElement)) {
@@ -599,14 +646,22 @@ export const textWysiwyg = ({
     // it'd get stuck in an infinite loop of blur→onSubmit after we re-focus the
     // wysiwyg on update
     cleanup();
-    const updateElement = app.scene.getElement(
-      element.id,
-    ) as ExcalidrawTextElement;
+    const updateElement = app.scene.getElement(element.id);
     if (!updateElement) {
       return;
     }
+
+    if (isStickyNoteElement(updateElement)) {
+      onSubmit({
+        viaKeyboard: submittedViaKeyboard,
+        nextOriginalText: editable.value,
+      });
+      return;
+    }
+
+    const textElement = updateElement as ExcalidrawTextElement;
     const container = getContainerElement(
-      updateElement,
+      textElement,
       app.scene.getNonDeletedElementsMap(),
     );
 
@@ -635,7 +690,7 @@ export const textWysiwyg = ({
         });
       }
 
-      redrawTextBoundingBox(updateElement, container, app.scene);
+      redrawTextBoundingBox(textElement, container, app.scene);
     }
 
     onSubmit({

--- a/packages/utils/src/shape.ts
+++ b/packages/utils/src/shape.ts
@@ -51,6 +51,7 @@ import type {
   ExcalidrawRectangleElement,
   ExcalidrawSelectionElement,
   ExcalidrawTextElement,
+  ExcalidrawStickyNoteElement,
 } from "@excalidraw/element/types";
 import type { Curve, LineSegment, Polygon, Radians } from "@excalidraw/math";
 
@@ -110,7 +111,8 @@ type RectangularElement =
   | ExcalidrawImageElement
   | ExcalidrawIframeElement
   | ExcalidrawTextElement
-  | ExcalidrawSelectionElement;
+  | ExcalidrawSelectionElement
+  | ExcalidrawStickyNoteElement;
 
 // polygon
 export const getPolygonShape = <Point extends GlobalPoint | LocalPoint>(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements the Sticky Note feature as described in #4. Adds a new `stickyNote` element type to Excalidraw with inline text storage, rendering, and editing capabilities.

## Changes

### New Element Type
- Defined `ExcalidrawStickyNoteElement` type with inline text fields (`text`, `fontSize`, `fontFamily`, `textAlign`, `verticalAlign`, `originalText`, `lineHeight`, `autoResize`)
- Added to `ExcalidrawElement` union, `ExcalidrawBindableElement`, `ExcalidrawRectanguloidElement`

### Toolbar & UI
- Added sticky note icon (folded page SVG) to the toolbar between Text and Image tools
- Added `stickyNote` to `TOOL_TYPE`, `ToolType`, and `AllowedExcalidrawActiveTools`
- Added i18n strings for toolbar and element labels

### Rendering
- Canvas rendering with yellow fill (#FDEFA3), rounded corners (~10px), subtle drop shadow, and inline text rendering with word wrapping
- SVG export rendering for sticky notes with text
- Shape generation using roughjs rounded rectangle path

### Interaction Model
- **On initial placement**: Single click places note AND immediately enters inline text editing mode (cursor auto-focuses)
- **On a placed note**: Single click selects (shows property panel), double-click enters text editing mode
- WYSIWYG text editing overlays the sticky note with proper positioning

### Integration
- Updated all element-type switches across the codebase (collision, distance, bounds, shape, comparisons, snapping, restore, etc.)
- Render cache invalidation when text changes
- Property panel support for fill, stroke, opacity, and stroke width

## Demo

[sticky_note_complete_demo.mp4](https://cursor.com/agents/bc-4d62a624-215c-551e-a2f3-1432f05c14ae/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsticky_note_complete_demo.mp4)

[Sticky note with text rendered](https://cursor.com/agents/bc-4d62a624-215c-551e-a2f3-1432f05c14ae/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshot_final_sticky_note.webp)

## Testing

- All 96 test files pass (1241 tests)
- TypeScript type checking passes with 0 errors
- ESLint passes with 0 warnings
- Manual testing verified all acceptance criteria

Closes #4
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://cursor-demoworkspace.slack.com/archives/C0AP12GJ9LL/p1774483312198539?thread_ts=1774483312.198539&cid=C0AP12GJ9LL)

<div><a href="https://cursor.com/agents/bc-4d62a624-215c-551e-a2f3-1432f05c14ae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4d62a624-215c-551e-a2f3-1432f05c14ae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

